### PR TITLE
DM-13167: Implement product tiles

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ recursive-include wwwlsstio *.html
 recursive-include wwwlsstio *.jinja
 recursive-include wwwlsstio *.css
 recursive-include wwwlsstio *.js
+recursive-include wwwlsstio *.yaml

--- a/scss/app.scss
+++ b/scss/app.scss
@@ -44,6 +44,7 @@
 @import "inuitcss/elements/elements.images";
 @import "inuitcss/elements/elements.tables";
 @import "elements/elements.page";
+@import "elements/elements.links";
 
 // ===========================================================================
 // OBJECTS
@@ -76,6 +77,7 @@
 @import "inuitcss/utilities/utilities.clearfix";
 @import "inuitcss/utilities/utilities.print";
 @import "inuitcss/utilities/utilities.hide";
+@import "utilities/utilities.links";
 
 // ===========================================================================
 // HACKS

--- a/scss/app.scss
+++ b/scss/app.scss
@@ -14,6 +14,7 @@
 @import "settings/settings.type";
 @import 'inuitcss/settings/settings.core';
 @import "settings/settings.global";
+@import "settings/settings.colors";
 
 // ===========================================================================
 // TOOLS
@@ -23,6 +24,7 @@
 @import "inuitcss/tools/tools.clearfix";
 @import "inuitcss/tools/tools.hidden";
 @import "sass-mq/mq";
+@import "tools/tools.fonts";
 
 // ===========================================================================
 // GENERIC
@@ -41,6 +43,7 @@
 @import "inuitcss/elements/elements.headings";
 @import "inuitcss/elements/elements.images";
 @import "inuitcss/elements/elements.tables";
+@import "elements/elements.page";
 
 // ===========================================================================
 // OBJECTS

--- a/scss/app.scss
+++ b/scss/app.scss
@@ -66,6 +66,7 @@
 // COMPONENTS
 // Discrete, complete chunks of UI.
 // ===========================================================================
+@import "components/components.project-tile";
 
 // ===========================================================================
 // UTILITIES

--- a/scss/components/_components.project-tile.scss
+++ b/scss/components/_components.project-tile.scss
@@ -40,6 +40,17 @@
   }
 
   &__description {
-    background-color: yellow;
+    // Constrain the height of the description text.
+    max-height: 200px;
+    overflow: auto;
+
+    // Use the shadow effect to give the users a hint that they can scroll
+    // This is based on Chapter 34 of CSS Secrets by Lea Verou.
+    background: linear-gradient(white 15px, hsla(0,0%,100%,0)) 0 0 / 100% 50px,
+                radial-gradient(at top, rgba(0,0,0,0.2), transparent 70%) 0 0 / 100% 15px,
+                linear-gradient(to top, white 15px, hsla(0,0%,100%,0)) bottom / 100% 50px,
+                radial-gradient(at bottom, rgba(0,0,0,0.2), transparent 70%) bottom / 100% 15px;
+    background-repeat: no-repeat;
+    background-attachment: local, scroll, local, scroll;
   }
 }

--- a/scss/components/_components.project-tile.scss
+++ b/scss/components/_components.project-tile.scss
@@ -1,0 +1,18 @@
+.c-project-tile-grid {
+  display: grid;
+  grid-auto-flow: row;
+  grid-auto-rows: auto;
+  grid-gap: 1em;
+  // Responsive grid; tiles can stretch to fill the space, but are still
+  // constrained.
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  // Equal height grid items.
+  align-items: stretch;  // equal height grid items
+}
+
+.c-project-tile {
+  border-radius: 4px;
+  background-color: #fff;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 3px 1px -2px rgba(0,0,0,.2),0 1px 5px 0 rgba(0,0,0,.12);
+  padding: 10px;
+}

--- a/scss/components/_components.project-tile.scss
+++ b/scss/components/_components.project-tile.scss
@@ -15,4 +15,31 @@
   background-color: #fff;
   box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 3px 1px -2px rgba(0,0,0,.2),0 1px 5px 0 rgba(0,0,0,.12);
   padding: 10px;
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    // This is a hack to remove the 1 line height top padding that this
+    // flex container gets with flex-direction column and the title/subtitle
+    // order reversed.
+    margin-top: -$inuit-global-line-height;
+  }
+
+  &__title {
+    order: 2;
+    margin-bottom: 0.5em;
+    @include source-sans-bold;
+    line-height: 1.1;
+  }
+
+  &__subtitle {
+    order: 1;
+    margin: 0;
+    padding: 0;
+    @include source-sans-bold;
+  }
+
+  &__description {
+    background-color: yellow;
+  }
 }

--- a/scss/elements/_elements.links.scss
+++ b/scss/elements/_elements.links.scss
@@ -1,0 +1,19 @@
+// ===========================================================================
+// #LINKS
+// ===========================================================================
+// Default styling for <a> link elements.
+
+// Based on rule 43 from typographychecklist.com
+a {
+  border-bottom: 1px solid $default-link-underline-color;
+  color: $default-type-color;
+  text-decoration: none;
+  // box-shadow: inset 0 -4px 0 $link-underline-color;
+  box-shadow: inset 0 -3px 0 $default-link-underline-color;
+  transition: background 0.3s ease-out;
+}
+
+
+a:hover {
+  background: $default-link-underline-color;
+}

--- a/scss/elements/_elements.page.scss
+++ b/scss/elements/_elements.page.scss
@@ -1,0 +1,10 @@
+// ===========================================================================
+// #PAGE
+// ===========================================================================
+// Customize the <html> and <body> elements
+
+body {
+  @include source-sans-regular;
+  color: $default-type-color;
+  background-color: $default-background-color;
+}

--- a/scss/settings/_settings.colors.scss
+++ b/scss/settings/_settings.colors.scss
@@ -6,5 +6,19 @@
 $ghost-white-color: #fafbfc;
 $dark-slate-grey-color: #25292e;
 
+// Colors from the LSST logo (two-blue stripe version)
+$logo-1: #000;
+$logo-2: #283f96;  // dark blue
+$logo-3: #526fb5;  // intermediate blue
+$logo-4: #ccdcf1;  // light blue
+$logo-red: #db1f26;
+
+// LSST.org palette
+// Colors from the project website
+$lsst-dark-background: #0c5c85; // a dark teal
+$lsst-bright-blue: #0099cc;  // a bright blue
+$lsst-white-blue: #c9eaf6;  // a white tinted blue
+
 $default-type-color: $dark-slate-grey-color;
 $default-background-color: $ghost-white-color;
+$default-link-underline-color: $logo-4;

--- a/scss/settings/_settings.colors.scss
+++ b/scss/settings/_settings.colors.scss
@@ -1,0 +1,10 @@
+// ===========================================================================
+// #COLORS
+// ===========================================================================
+// Color palette.
+
+$ghost-white-color: #fafbfc;
+$dark-slate-grey-color: #25292e;
+
+$default-type-color: $dark-slate-grey-color;
+$default-background-color: $ghost-white-color;

--- a/scss/settings/_settings.type.scss
+++ b/scss/settings/_settings.type.scss
@@ -7,3 +7,7 @@
 // Override inuitcss/settings/settings.core
 $inuit-global-font-size: 16px;
 $inuit-global-line-height: 22.4px;
+
+// Source Sans font stack that falls back to system fonts
+// https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/#what-to-do-today
+$source-sans-stack: "source-sans-pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;

--- a/scss/tools/_tools.fonts.scss
+++ b/scss/tools/_tools.fonts.scss
@@ -1,0 +1,22 @@
+// ===========================================================================
+// #FONTS
+// ===========================================================================
+// Font mixins to use Source Sans.
+
+@mixin source-sans-regular {
+  font-family: $source-sans-stack;
+  font-weight: 400;
+  font-style: normal
+}
+
+@mixin source-sans-italic {
+  font-family: $source-sans-stack;
+  font-weight: 400;
+  font-style: italic
+}
+
+@mixin source-sans-bold {
+  font-family: $source-sans-stack;
+  font-weight: 700;
+  font-style: normal
+}

--- a/scss/utilities/_utilities.links.scss
+++ b/scss/utilities/_utilities.links.scss
@@ -1,0 +1,16 @@
+// ===========================================================================
+// #LINKS
+// ===========================================================================
+// Utility classes for styling links.
+
+
+a.u-hidden-link {
+  // undo default <a> style
+  box-shadow: unset !important;
+  border-bottom: unset !important;
+  text-decoration: none;
+}
+
+a.u-hidden-link--no-hover {
+  background: unset !important;
+}

--- a/setup.py
+++ b/setup.py
@@ -34,13 +34,15 @@ setup(
     keywords='lsst lsst-the-docs',
     packages=find_packages(exclude=('tests',)),
     use_scm_version=True,
+    include_package_data=True,
     setup_requires=[
         'setuptools-scm==1.15.6',
     ],
     install_requires=[
         'Flask==0.12.2',
         'Jinja2==2.10',
-        'Frozen-Flask==0.15'
+        'Frozen-Flask==0.15',
+        'PyYAML==3.12'
     ],
     extras_require={},
     entry_points={

--- a/wwwlsstio/data/document-demo.yaml
+++ b/wwwlsstio/data/document-demo.yaml
@@ -1,0 +1,43 @@
+# Demo data for documents LDM, LSE, DMTN
+
+- title: "Data Management Database Design"
+  handle: "LDM-135"
+  abstract_html: "<p>This document discusses the LSST database system architecture.</p>"
+  url: "https://ldm-135.lsst.io"
+  github_slug: "lsst/LDM-135"
+
+- title: "Data Management Applications Design"
+  handle: "LDM-151"
+  abstract_html: "<p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>"
+  url: "https://ldm-151.lsst.io"
+  github_slug: "lsst/LDM-151"
+
+- title: "Data Management Middleware Design"
+  handle: "LDM-152"
+  abstract_html: "<p>The LSST middleware is designed to isolate scientific application pipelines and payloads, including the Alert Production, Data Release Production, Calibration Products Productions, and science user pipelines executed within the LSST Science Platform, from details of the underlying hardware and system software. It enables flexible reuse of the same code in multiple environments ranging from offline laptops to shared-memory multiprocessors to grid-accessed clusters, with a common I/O and logging model. It ensures that key scientific and deployment parameters controlling execution can be easily modified without changing code but also with full provenance to understand what environment and parameters were used to produce any dataset. It provides flexible, high-performance, low-overhead persistence and retrieval of datasets with data repositories and formats selected by external parameters rather than hard-coding. Middleware services enable efficient, managed replication of data over both wide area networks and local area networks.</p>"
+  url: "https://ldm-152.lsst.io"
+  github_slug: "lsst/LDM-152"
+
+- title: "Data Management Organization and Management"
+  handle: "LDM-294"
+  abstract_html: "<p>This management plan covers the organization and management of the Data Management (DM) subsystem during the development, construction, and commissioning of LSST. It sets out DM goals and lays out the management organization roles and responsibilities to achieve them. It provides a high level overview of DM architecture, products and processes. It provides a structured starting point for understanding DM and pointers to further documentation.</p>"
+  url: "https://ldm-294.lsst.io"
+  github_slug: "lsst/LDM-294"
+
+- title: "Concept of Operations for the LSST Data Facility Services"
+  handle: "LDM-230"
+  abstract_html: "<p>This document describes the operational concepts for the emerging LSST Data Facility, which will operate the system that will be delivered by the LSST construction project. The services will be incrementally deployed and operated by the construction project as part of verification and validation activities within the construction project.</p>"
+  url: "https://ldm-230.lsst.io"
+  github_slug: "lsst/LDM-230"
+
+- title: "Data Management Test Plan"
+  handle: "LDM-503"
+  abstract_html: "<p>This is the Test Plan for Data Management. In it we define terms associated with testing and further test specifications for specific items.</p>"
+  url: "https://ldm-503.lsst.io"
+  github_slug: "lsst/LDM-503"
+
+- title: "Data Management System Requirements"
+  handle: "LSE-61"
+  abstract_html: "<p></p>"
+  url: "https://ldm-61.lsst.io"
+  github_slug: "lsst/LDM-61"

--- a/wwwlsstio/templates/homepage.jinja
+++ b/wwwlsstio/templates/homepage.jinja
@@ -12,11 +12,102 @@
 </head>
 
 <body class="wwwlsstio-page">
+  <section class="o-wrapper">
+    <h1>LSST Documentation Hub</h1>
 
-<h1>Hello world</h1>
+    <section class="c-project-tile-grid">
+      <article class="c-project-tile">
+        <a href="https://ldm-151.lsst.io">
+          <h2>Data Management Applications Design</h2>
+          <p>LDM-151<p>
+        </a>
+        <p><a href="">ldm-151.lsst.io</a></p>
+        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
+      </article>
 
-<p>This is www.lsst.io.</p>
+      <article class="c-project-tile">
+        <a href="https://ldm-151.lsst.io">
+          <h2>Data Management Applications Design</h2>
+          <p>LDM-151<p>
+        </a>
+        <p><a href="">ldm-151.lsst.io</a></p>
+        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
+      </article>
 
+      <article class="c-project-tile">
+        <a href="https://ldm-151.lsst.io">
+          <h2>Data Management Applications Design</h2>
+          <p>LDM-151<p>
+        </a>
+        <p><a href="">ldm-151.lsst.io</a></p>
+        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
+      </article>
+
+      <article class="c-project-tile">
+        <a href="https://ldm-151.lsst.io">
+          <h2>Data Management Applications Design</h2>
+          <p>LDM-151<p>
+        </a>
+        <p><a href="">ldm-151.lsst.io</a></p>
+        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
+      </article> 
+
+      <article class="c-project-tile">
+        <a href="https://ldm-151.lsst.io">
+          <h2>Data Management Applications Design</h2>
+          <p>LDM-151<p>
+        </a>
+        <p><a href="">ldm-151.lsst.io</a></p>
+        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
+      </article>
+
+      <article class="c-project-tile">
+        <a href="https://ldm-151.lsst.io">
+          <h2>Data Management Applications Design</h2>
+          <p>LDM-151<p>
+        </a>
+        <p><a href="">ldm-151.lsst.io</a></p>
+        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
+      </article>
+
+      <article class="c-project-tile">
+        <a href="https://ldm-151.lsst.io">
+          <h2>Data Management Applications Design</h2>
+          <p>LDM-151<p>
+        </a>
+        <p><a href="">ldm-151.lsst.io</a></p>
+        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
+      </article>
+
+      <article class="c-project-tile">
+        <a href="https://ldm-151.lsst.io">
+          <h2>Data Management Applications Design</h2>
+          <p>LDM-151<p>
+        </a>
+        <p><a href="">ldm-151.lsst.io</a></p>
+        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
+      </article>
+
+      <article class="c-project-tile">
+        <a href="https://ldm-151.lsst.io">
+          <h2>Data Management Applications Design</h2>
+          <p>LDM-151<p>
+        </a>
+        <p><a href="">ldm-151.lsst.io</a></p>
+        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
+      </article> 
+
+      <article class="c-project-tile">
+        <a href="https://ldm-151.lsst.io">
+          <h2>Data Management Applications Design</h2>
+          <p>LDM-151<p>
+        </a>
+        <p><a href="">ldm-151.lsst.io</a></p>
+        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
+      </article>
+
+    </section>
+  </section>
 </body>
 
 </html>

--- a/wwwlsstio/templates/homepage.jinja
+++ b/wwwlsstio/templates/homepage.jinja
@@ -19,10 +19,16 @@
 
       {% for item in data %}
         <article class="c-project-tile">
-          <h2><a href="{{ item.url  }}">{{ item.title }}</a></h2>
-          <p>{{ item.handle }}<p>
+          <header class="c-project-tile__header">
+            <h2 class="c-project-tile__title"><a class="u-hidden-link" href="{{ item.url  }}">{{ item.title }}</a></h2>
+            <p class="c-project-tile__subtitle">{{ item.handle }}<p>
+          </header>
+
           <p><a href="{{ item.url }}">{{ item.url }}</a></p>
-          {{ item.abstract_html|safe }}
+
+          <section class="c-project-tile__description">
+            {{ item.abstract_html|safe }}
+          </section>
         </article>
       {% endfor %}
 

--- a/wwwlsstio/templates/homepage.jinja
+++ b/wwwlsstio/templates/homepage.jinja
@@ -8,6 +8,7 @@
   {# <meta name="description" content="{{ config['page_description'] }}"> #}
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='app.css') }}">
+  <link rel="stylesheet" href="https://use.typekit.net/alj0azf.css">
 </head>
 
 <body class="wwwlsstio-page">

--- a/wwwlsstio/templates/homepage.jinja
+++ b/wwwlsstio/templates/homepage.jinja
@@ -16,95 +16,15 @@
     <h1>LSST Documentation Hub</h1>
 
     <section class="c-project-tile-grid">
-      <article class="c-project-tile">
-        <a href="https://ldm-151.lsst.io">
-          <h2>Data Management Applications Design</h2>
-          <p>LDM-151<p>
-        </a>
-        <p><a href="">ldm-151.lsst.io</a></p>
-        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
-      </article>
 
-      <article class="c-project-tile">
-        <a href="https://ldm-151.lsst.io">
-          <h2>Data Management Applications Design</h2>
-          <p>LDM-151<p>
-        </a>
-        <p><a href="">ldm-151.lsst.io</a></p>
-        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
-      </article>
-
-      <article class="c-project-tile">
-        <a href="https://ldm-151.lsst.io">
-          <h2>Data Management Applications Design</h2>
-          <p>LDM-151<p>
-        </a>
-        <p><a href="">ldm-151.lsst.io</a></p>
-        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
-      </article>
-
-      <article class="c-project-tile">
-        <a href="https://ldm-151.lsst.io">
-          <h2>Data Management Applications Design</h2>
-          <p>LDM-151<p>
-        </a>
-        <p><a href="">ldm-151.lsst.io</a></p>
-        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
-      </article> 
-
-      <article class="c-project-tile">
-        <a href="https://ldm-151.lsst.io">
-          <h2>Data Management Applications Design</h2>
-          <p>LDM-151<p>
-        </a>
-        <p><a href="">ldm-151.lsst.io</a></p>
-        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
-      </article>
-
-      <article class="c-project-tile">
-        <a href="https://ldm-151.lsst.io">
-          <h2>Data Management Applications Design</h2>
-          <p>LDM-151<p>
-        </a>
-        <p><a href="">ldm-151.lsst.io</a></p>
-        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
-      </article>
-
-      <article class="c-project-tile">
-        <a href="https://ldm-151.lsst.io">
-          <h2>Data Management Applications Design</h2>
-          <p>LDM-151<p>
-        </a>
-        <p><a href="">ldm-151.lsst.io</a></p>
-        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
-      </article>
-
-      <article class="c-project-tile">
-        <a href="https://ldm-151.lsst.io">
-          <h2>Data Management Applications Design</h2>
-          <p>LDM-151<p>
-        </a>
-        <p><a href="">ldm-151.lsst.io</a></p>
-        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
-      </article>
-
-      <article class="c-project-tile">
-        <a href="https://ldm-151.lsst.io">
-          <h2>Data Management Applications Design</h2>
-          <p>LDM-151<p>
-        </a>
-        <p><a href="">ldm-151.lsst.io</a></p>
-        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
-      </article> 
-
-      <article class="c-project-tile">
-        <a href="https://ldm-151.lsst.io">
-          <h2>Data Management Applications Design</h2>
-          <p>LDM-151<p>
-        </a>
-        <p><a href="">ldm-151.lsst.io</a></p>
-        <p>The LSST Science Requirements Document (the LSST SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document (DPDD), and captured in a formal flow-down from the SRD via the LSST System Requirements (LSR), Observatory System Specifications (OSS), to the Data Management System Requirements (DMSR). The LSST Data Management subsystem’s responsibilities include the design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document describes the design of the scientific aspects of those pipelines.</p>
-      </article>
+      {% for item in data %}
+        <article class="c-project-tile">
+          <h2><a href="{{ item.url  }}">{{ item.title }}</a></h2>
+          <p>{{ item.handle }}<p>
+          <p><a href="{{ item.url }}">{{ item.url }}</a></p>
+          {{ item.abstract_html|safe }}
+        </article>
+      {% endfor %}
 
     </section>
   </section>

--- a/wwwlsstio/views/homepage.py
+++ b/wwwlsstio/views/homepage.py
@@ -1,7 +1,10 @@
 """Homepage view.
 """
 
+import os
+
 from flask import render_template
+import yaml
 
 from . import view_blueprint
 
@@ -9,4 +12,9 @@ from . import view_blueprint
 @view_blueprint.route('/', methods=['GET'])
 def get_homepage():
     """Homepage view."""
-    return render_template('homepage.jinja')
+    demo_data_path = os.path.join(os.path.dirname(__file__),
+                                  '../data/document-demo.yaml')
+    with open(demo_data_path) as f:
+        demo_data = yaml.load(f)
+
+    return render_template('homepage.jinja', data=demo_data)


### PR DESCRIPTION
This PR implements a grid-based product tile layout. These tiles are used for index pages to help folks browse products (documents, source code, etc.).

- CSS Grid layout
- Basic typography
- Implement an affordance for long abstracts that limits their screen size, yet lets folks know when there is more abstract content to scroll over.