### PR TITLE
DM-13245: Generate site from Projectmeta DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help server watch scss version site
+.PHONY: help server watch scss version site deploy
 
 help:
 	@echo "Run these commands in separate shells:"
@@ -7,6 +7,7 @@ help:
 	@echo "  make scss        (compile scss for production)"
 	@echo "  make version     (print app version)"
 	@echo "  make site        (build static site for deployment)"
+	@echo "  make deploy      (deploy site to LSST the Docs)"
 
 server:
 	FLASK_DEBUG=1 WWWLSSTIO_PROFILE=dev FLASK_APP=wwwlsstio:app flask run
@@ -22,3 +23,6 @@ version:
 
 site:
 	FLASK_APP=wwwlsstio:app flask build
+
+deploy:
+	LTD_KEEPER_URL=https://keeper.lsst.codes LTD_MASON_PRODUCT=www LTD_MASON_BUILD=true TRAVIS_PULL_REQUEST=false TRAVIS_REPO_SLUG=lsst-sqre/ltd-mason TRAVIS_BRANCH=master ltd-mason-travis --html-dir _build

--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,27 @@ www.lsst.io
 www.lsst.io is a portal for LSST project information and metadata.
 It's designed to help LSST staff and the astronomy community discover documentation, software, and other bits of information produced by the LSST project.
 
+Development set up
+==================
+
+This project relies on both Python 3.5 (and newer) and Node.js (with npm).
+
+Install the node dependencies by running::
+
+   npm install
+
+You can install the Python dependencies for local development by running::
+
+   pip install -e .
+
 Development workflow
 ====================
 
-Use the local development server to preview and iterate on the site.
+You can test the Python backend by running the Python unit tests by running::
+
+   make test
+
+To iterate on the site design, use the local development server:
 
 1. Set the ``PROJECTMETA_MONGO`` environment variable with the URI for Projectmeta's MongoDB (``mongodb://`` or ``mongodb+srv://``).
 
@@ -16,12 +33,12 @@ Use the local development server to preview and iterate on the site.
 
      make server
 
-3. In second terminal, start Browsersync and the Gulp asset pipeline::
+3. In second terminal, start Browsersync_ and the Gulp asset pipeline::
 
      make watch
 
 4. Follow the printed instructions to view the site, likely at http://localhost:3000
 
-Browsersync streams CSS changes to the browser and application changes trigger a browser reload.
+Browsersync_ streams CSS changes to the browser and application changes trigger a browser reload.
 
 .. _Browsersync: https://browsersync.io

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,8 @@ www.lsst.io
 www.lsst.io is a portal for LSST project information and metadata.
 It's designed to help LSST staff and the astronomy community discover documentation, software, and other bits of information produced by the LSST project.
 
+The site uses data acquired separately by pipelines in the `lsst-projectmeta-kit`_ package.
+
 Development set up
 ==================
 
@@ -41,4 +43,30 @@ To iterate on the site design, use the local development server:
 
 Browsersync_ streams CSS changes to the browser and application changes trigger a browser reload.
 
+Deployment
+==========
+
+Set the following environment variables for LSST the Docs and Projectmeta:
+
+- ``LTD_KEEPER_USER`` — Password for LTD Keeper instance.
+- ``LTD_KEEPER_PASSWORD`` — Username for LTD Keeper instance.
+- ``LTD_MASON_AWS_ID`` — AWS access key ID.
+- ``LTD_MASON_AWS_SECRET`` — AWS secret access key.
+- ``PROJECTMETA_MONGO`` — URI of Projectmeta's MongoDB (``mongodb://`` or ``mongodb+srv://``).
+
+Then:
+
+1. Compile the Sass::
+
+      make scss
+
+2. Compile the static HTML site::
+
+      make site
+
+3. Deploy the site::
+
+      make deploy
+
 .. _Browsersync: https://browsersync.io
+.. _lsst-projectmeta-kit: https://github.com/lsst-sqre/lsst-projectmeta-kit

--- a/README.rst
+++ b/README.rst
@@ -10,14 +10,18 @@ Development workflow
 
 Use the local development server to preview and iterate on the site.
 
-1. In one terminal, start the Flask server::
+1. Set the ``PROJECTMETA_MONGO`` environment variable with the URI for Projectmeta's MongoDB (``mongodb://`` or ``mongodb+srv://``).
+
+2. Start the Flask server::
 
      make server
 
-2. In another terminal, start Browsersync and the Gulp asset pipeline::
+3. In second terminal, start Browsersync and the Gulp asset pipeline::
 
      make watch
 
-3. Follow the printed instructions to view the site, likely at http://localhost:3000
+4. Follow the printed instructions to view the site, likely at http://localhost:3000
 
 Browsersync streams CSS changes to the browser and application changes trigger a browser reload.
+
+.. _Browsersync: https://browsersync.io

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Use the local development server to preview and iterate on the site.
 
 2. In another terminal, start Browsersync and the Gulp asset pipeline::
 
-     make browser-sync
+     make watch
 
 3. Follow the printed instructions to view the site, likely at http://localhost:3000
 

--- a/scss/app.scss
+++ b/scss/app.scss
@@ -68,6 +68,7 @@
 // Discrete, complete chunks of UI.
 // ===========================================================================
 @import "components/components.project-tile";
+@import "components/components.author-list";
 
 // ===========================================================================
 // UTILITIES

--- a/scss/components/_components.author-list.scss
+++ b/scss/components/_components.author-list.scss
@@ -1,0 +1,46 @@
+// Comma separated author lists
+//
+// Turns an unordered list into an inline list with commas between items,
+// and an Oxford comma after the last. For a list of two items only " and "
+// is inserted.
+//
+// Based on http://stackoverflow.com/a/6587877
+
+
+// c-author-list makes a ul an inline list with grammatical comma separated
+// items.
+.c-author-list {
+  display: inline;
+  list-style: none;
+  margin-left: 0;
+}
+
+
+.c-author-list li {
+  display: inline;
+}
+
+
+// Comma after c-author-list items
+.c-author-list li:after {
+  content: ", ";
+}
+
+
+// No comma after the last item.
+.c-author-list li:last-child:after {
+  content: "";
+}
+
+
+// For a two item list separate with only " and ".
+.c-author-list li:nth-last-child(2):after {
+  content: " and ";
+}
+
+
+// For a three or more item list, put an Oxford comma after the second list
+// item.
+.c-author-list li:nth-last-child(3) ~ li:nth-last-child(2):after {
+    content: ", and ";
+}

--- a/scss/components/_components.project-tile.scss
+++ b/scss/components/_components.project-tile.scss
@@ -50,10 +50,8 @@
     margin-bottom: 1em;
   }
 
-  // Hack to push the datetime down the tile.
-  // I'm not entirely sure why we need to eat up the bottom margin.
   &__description + &__datetime {
-    margin-top: 1em;
+    // I'm not entirely sure why we need to eat up the bottom margin.
     margin-bottom: -1em;
   }
 

--- a/scss/components/_components.project-tile.scss
+++ b/scss/components/_components.project-tile.scss
@@ -46,6 +46,10 @@
     @include source-sans-bold;
   }
 
+  &__authors {
+    margin-bottom: 1em;
+  }
+
   &__description {
     // Constrain the height of the description text.
     max-height: 200px;

--- a/scss/components/_components.project-tile.scss
+++ b/scss/components/_components.project-tile.scss
@@ -50,6 +50,13 @@
     margin-bottom: 1em;
   }
 
+  // Hack to push the datetime down the tile.
+  // I'm not entirely sure why we need to eat up the bottom margin.
+  &__description + &__datetime {
+    margin-top: 1em;
+    margin-bottom: -1em;
+  }
+
   &__description {
     // Constrain the height of the description text.
     max-height: 200px;

--- a/scss/components/_components.project-tile.scss
+++ b/scss/components/_components.project-tile.scss
@@ -1,3 +1,9 @@
+// For section elements that includes a c-project-tile-grid along with
+// optional elements like a header and footer.
+.c-tile-section + .c-tile-section {
+  margin-top: 5em;
+}
+
 .c-project-tile-grid {
   display: grid;
   grid-auto-flow: row;
@@ -8,6 +14,7 @@
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   // Equal height grid items.
   align-items: stretch;  // equal height grid items
+  margin-bottom: 2em;
 }
 
 .c-project-tile {

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
         'Flask==0.12.2',
         'Jinja2==2.10',
         'Frozen-Flask==0.15',
-        'PyYAML==3.12'
+        'PyYAML==3.12',
+        'pymongo==3.6.0'
     ],
     extras_require={},
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
         'Jinja2==2.10',
         'Frozen-Flask==0.15',
         'PyYAML==3.12',
-        'pymongo==3.6.0'
+        'pymongo==3.6.0',
+        'ltd-mason==0.2.5'
     ],
     extras_require={},
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Frozen-Flask==0.15',
         'PyYAML==3.12',
         'pymongo==3.6.0',
+        'misaka==2.1.0',
         'ltd-mason==0.2.5'
     ],
     extras_require={},

--- a/wwwlsstio/appfactory.py
+++ b/wwwlsstio/appfactory.py
@@ -38,4 +38,9 @@ def create_app(profile='prod'):
     from .views import view_blueprint
     app.register_blueprint(view_blueprint, url_prefix=None)
 
+    # Because of the order of imports and app creation, I'm creating
+    # the teardown callback here.
+    from .mongo import init_mongo_teardown
+    init_mongo_teardown(app)
+
     return app

--- a/wwwlsstio/appfactory.py
+++ b/wwwlsstio/appfactory.py
@@ -8,6 +8,7 @@ import os
 from flask import Flask
 
 from .config import config
+from .filters import register_filters
 
 
 def create_app(profile='prod'):
@@ -42,5 +43,8 @@ def create_app(profile='prod'):
     # the teardown callback here.
     from .mongo import init_mongo_teardown
     init_mongo_teardown(app)
+
+    # Jinja filters
+    register_filters(app)
 
     return app

--- a/wwwlsstio/config.py
+++ b/wwwlsstio/config.py
@@ -19,6 +19,8 @@ class Config(object):
     FREEZER_DESTINATION = os.path.join(os.path.abspath(os.getcwd()), '_build')
     FREEZER_RELATIVE_URLS = True
 
+    MONGO_URI = os.getenv('PROJECTMETA_MONGO', default=None)
+
     @abc.abstractclassmethod
     def init_app(cls, app):
         pass

--- a/wwwlsstio/filters.py
+++ b/wwwlsstio/filters.py
@@ -5,6 +5,8 @@ __all__ = ('register_filters',)
 
 from urllib.parse import urlparse
 
+import misaka
+
 
 def register_filters(app):
     """Add filters to the Flask application's Jinja environment.
@@ -15,6 +17,7 @@ def register_filters(app):
     app.jinja_env.filters['format_iso_8601_date'] = format_iso_8061_date
     app.jinja_env.filters['format_iso_8601_datetime'] \
         = format_iso_8061_datetime
+    app.jinja_env.filters['markdown'] = format_markdown
 
 
 def strip_protocol(url):
@@ -48,3 +51,9 @@ def format_iso_8061_datetime(value):
     """Format a `datetime.datetime` into a full ISO 8601 datetime string.
     """
     return value.isoformat(sep='T')
+
+
+def format_markdown(content):
+    """Format text Markdown/HTML content into HTML.
+    """
+    return misaka.html(content)

--- a/wwwlsstio/filters.py
+++ b/wwwlsstio/filters.py
@@ -1,0 +1,22 @@
+"""Jinja template filters.
+"""
+
+__all__ = ('register_filters',)
+
+from urllib.parse import urlparse
+
+
+def register_filters(app):
+    """Add filters to the Flask application's Jinja environment.
+    """
+    app.jinja_env.filters['strip_protocol'] = strip_protocol
+
+
+def strip_protocol(url):
+    """Reduce a URL to just the domain and path.
+
+    >>> strip_protocol('https://dmtn-068.lsst.io')
+    'dmtn-068.lsst.io'
+    """
+    parsed_url = urlparse(url)
+    return parsed_url.netloc + parsed_url.path

--- a/wwwlsstio/filters.py
+++ b/wwwlsstio/filters.py
@@ -10,6 +10,8 @@ def register_filters(app):
     """Add filters to the Flask application's Jinja environment.
     """
     app.jinja_env.filters['strip_protocol'] = strip_protocol
+    app.jinja_env.filters['format_schema_author_name'] \
+        = format_schema_author_name
 
 
 def strip_protocol(url):
@@ -20,3 +22,14 @@ def strip_protocol(url):
     """
     parsed_url = urlparse(url)
     return parsed_url.netloc + parsed_url.path
+
+
+def format_schema_author_name(author):
+    """For a JSON schema.org author node into a name
+    """
+    if 'name' in author:
+        return author['name']
+    else:
+        # NOTE: there may be other ways to encode a name in schema.org JSON,
+        # so this function may have to be expanded to deal with those.
+        return 'unknown'

--- a/wwwlsstio/filters.py
+++ b/wwwlsstio/filters.py
@@ -12,6 +12,9 @@ def register_filters(app):
     app.jinja_env.filters['strip_protocol'] = strip_protocol
     app.jinja_env.filters['format_schema_author_name'] \
         = format_schema_author_name
+    app.jinja_env.filters['format_iso_8601_date'] = format_iso_8061_date
+    app.jinja_env.filters['format_iso_8601_datetime'] \
+        = format_iso_8061_datetime
 
 
 def strip_protocol(url):
@@ -33,3 +36,15 @@ def format_schema_author_name(author):
         # NOTE: there may be other ways to encode a name in schema.org JSON,
         # so this function may have to be expanded to deal with those.
         return 'unknown'
+
+
+def format_iso_8061_date(value):
+    """Format a `datetime.datetime` into a 'YYYY-MM-DD' (ISO 8601) date string.
+    """
+    return value.strftime('%Y-%m-%d')
+
+
+def format_iso_8061_datetime(value):
+    """Format a `datetime.datetime` into a full ISO 8601 datetime string.
+    """
+    return value.isoformat(sep='T')

--- a/wwwlsstio/mongo.py
+++ b/wwwlsstio/mongo.py
@@ -1,0 +1,36 @@
+"""MongoDB connection management.
+"""
+__all__ = ['get_mongo']
+
+from flask import g, current_app
+from pymongo import MongoClient
+
+
+def get_mongo():
+    """Create a MongoDB client attached to the application context.
+    """
+    mongo_client = getattr(g, '_mongo_client', None)
+
+    if mongo_client is None:
+        uri = current_app.config['MONGO_URI']
+        if uri is None:
+            message = ('The PROJECTMETA_MONGO environment variable must be '
+                       'set to the URI of the projecmeta database.')
+            raise RuntimeError(message)
+        mongo_client = MongoClient(uri)
+        g._mongo_client = mongo_client
+
+    return mongo_client
+
+
+def init_mongo_teardown(app):
+    """Factory for the MongoDB client teardown function.
+    """
+
+    @app.teardown_appcontext
+    def teardown_mongo(exception):
+        """Teardown the MongoDB client when the application shuts down.
+        """
+        mongo_client = getattr(g, '_mongo_client', None)
+        if mongo_client is not None:
+            mongo_client.close()

--- a/wwwlsstio/templates/_project-tile.jinja
+++ b/wwwlsstio/templates/_project-tile.jinja
@@ -32,9 +32,11 @@ current_header_level : int, optional
   </section>
   {% endif %}
 
+  {% if item.description %}
   <section class="c-project-tile__description">
-    {{ item.description|safe }}
+    {{ item.description | markdown | safe }}
   </section>
+  {% endif %}
 
   {% if item.dateModified %}
     <p class="c-project-tile__datetime"><time datetime="{{ item.dateModified | format_iso_8601_datetime }}">{{ item.dateModified | format_iso_8601_date }}</time><p>

--- a/wwwlsstio/templates/_project-tile.jinja
+++ b/wwwlsstio/templates/_project-tile.jinja
@@ -35,4 +35,8 @@ current_header_level : int, optional
   <section class="c-project-tile__description">
     {{ item.description|safe }}
   </section>
+
+  {% if item.dateModified %}
+    <p class="c-project-tile__datetime"><time datetime="{{ item.dateModified | format_iso_8601_datetime }}">{{ item.dateModified | format_iso_8601_date }}</time><p>
+  {% endif %}
 </article>

--- a/wwwlsstio/templates/_project-tile.jinja
+++ b/wwwlsstio/templates/_project-tile.jinja
@@ -1,0 +1,28 @@
+{# project-tile partial
+
+Use this inside a <section class="c-project-tile-grid">.
+
+Variables
+---------
+item
+  An object with project data attributes.
+current_header_level : int, optional
+  Header level that should be used as the title. Default is 2 (for <h2>).
+#}
+
+{% if current_header_level is not defined %}
+  {% set current_header_level = 2 %}
+{% endif %}
+
+<article class="c-project-tile">
+  <header class="c-project-tile__header">
+    <h{{ current_header_level }} class="c-project-tile__title"><a class="u-hidden-link" href="{{ item.url  }}">{{ item.title }}</a></h{{ current_header_level}}>
+    <p class="c-project-tile__subtitle">{{ item.handle }}<p>
+  </header>
+
+  <p><a href="{{ item.url }}">{{ item.url }}</a></p>
+
+  <section class="c-project-tile__description">
+    {{ item.abstract_html|safe }}
+  </section>
+</article>

--- a/wwwlsstio/templates/_project-tile.jinja
+++ b/wwwlsstio/templates/_project-tile.jinja
@@ -22,6 +22,16 @@ current_header_level : int, optional
 
   <p><a href="{{ item.url }}">{{ item.url | strip_protocol }}</a></p>
 
+  {% if item.author %}
+  <section class="c-project-tile__authors">
+    <ul class="c-author-list">
+      {% for author in item.author %}
+        <li>{{ author | format_schema_author_name }}</li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
+
   <section class="c-project-tile__description">
     {{ item.description|safe }}
   </section>

--- a/wwwlsstio/templates/_project-tile.jinja
+++ b/wwwlsstio/templates/_project-tile.jinja
@@ -16,13 +16,13 @@ current_header_level : int, optional
 
 <article class="c-project-tile">
   <header class="c-project-tile__header">
-    <h{{ current_header_level }} class="c-project-tile__title"><a class="u-hidden-link" href="{{ item.url  }}">{{ item.title }}</a></h{{ current_header_level}}>
-    <p class="c-project-tile__subtitle">{{ item.handle }}<p>
+    <h{{ current_header_level }} class="c-project-tile__title"><a class="u-hidden-link" href="{{ item.url  }}">{{ item.name }}</a></h{{ current_header_level}}>
+    <p class="c-project-tile__subtitle">{{ item.reportNumber }}<p>
   </header>
 
   <p><a href="{{ item.url }}">{{ item.url }}</a></p>
 
   <section class="c-project-tile__description">
-    {{ item.abstract_html|safe }}
+    {{ item.description|safe }}
   </section>
 </article>

--- a/wwwlsstio/templates/_project-tile.jinja
+++ b/wwwlsstio/templates/_project-tile.jinja
@@ -20,7 +20,7 @@ current_header_level : int, optional
     <p class="c-project-tile__subtitle">{{ item.reportNumber }}<p>
   </header>
 
-  <p><a href="{{ item.url }}">{{ item.url }}</a></p>
+  <p><a href="{{ item.url }}">{{ item.url | strip_protocol }}</a></p>
 
   <section class="c-project-tile__description">
     {{ item.description|safe }}

--- a/wwwlsstio/templates/homepage.jinja
+++ b/wwwlsstio/templates/homepage.jinja
@@ -12,8 +12,17 @@
 </head>
 
 <body class="wwwlsstio-page">
-  <section class="o-wrapper">
+  <main class="o-wrapper">
     <h1>LSST Documentation Hub</h1>
+
+    <nav>
+      <h2>On this page</h2>
+      <ul>
+        <li><a href="#dmtn">LSST Data Management Technical Notes (DMTN)</a></li>
+        <li><a href="#sqr">LSST SQuaRE Technical Notes (SQR)</a></li>
+        <li><a href="#smtn">LSST Simulations Technical Notes (SMTN)</a></li>
+      </ul>
+    </nav>
 
     <section id="dmtn" class="c-tile-section">
       <h2>LSST Data Management Technical Notes</h2>
@@ -54,7 +63,7 @@
       </div>
     </section>
 
-  </section>
+  </main>
 </body>
 
 </html>

--- a/wwwlsstio/templates/homepage.jinja
+++ b/wwwlsstio/templates/homepage.jinja
@@ -17,19 +17,9 @@
 
     <section class="c-project-tile-grid">
 
+      {% set current_header_level = 2 %}
       {% for item in data %}
-        <article class="c-project-tile">
-          <header class="c-project-tile__header">
-            <h2 class="c-project-tile__title"><a class="u-hidden-link" href="{{ item.url  }}">{{ item.title }}</a></h2>
-            <p class="c-project-tile__subtitle">{{ item.handle }}<p>
-          </header>
-
-          <p><a href="{{ item.url }}">{{ item.url }}</a></p>
-
-          <section class="c-project-tile__description">
-            {{ item.abstract_html|safe }}
-          </section>
-        </article>
+        {% include "_project-tile.jinja" %}
       {% endfor %}
 
     </section>

--- a/wwwlsstio/templates/homepage.jinja
+++ b/wwwlsstio/templates/homepage.jinja
@@ -15,14 +15,45 @@
   <section class="o-wrapper">
     <h1>LSST Documentation Hub</h1>
 
-    <section class="c-project-tile-grid">
+    <section id="dmtn" class="c-tile-section">
+      <h2>LSST Data Management Technical Notes</h2>
 
-      {% set current_header_level = 2 %}
-      {% for item in data %}
-        {% include "_project-tile.jinja" %}
-      {% endfor %}
+      <div class="c-project-tile-grid">
+        {# Set header level used for project tiles #}
+        {% set current_header_level = 3 %}
 
+        {% for item in datasets['DMTN'] %}
+          {% include "_project-tile.jinja" %}
+        {% endfor %}
+      </div>
     </section>
+
+    <section id="sqr" class="c-tile-section">
+      <h2>LSST SQuaRE Technical Notes</h2>
+
+      <div class="c-project-tile-grid">
+        {# Set header level used for project tiles #}
+        {% set current_header_level = 3 %}
+
+        {% for item in datasets['SQR'] %}
+          {% include "_project-tile.jinja" %}
+        {% endfor %}
+      </div>
+    </section>
+
+    <section id="smtn" class="c-tile-section">
+      <h2>LSST Simulations Technical Notes</h2>
+
+      <div class="c-project-tile-grid">
+        {# Set header level used for project tiles #}
+        {% set current_header_level = 3 %}
+
+        {% for item in datasets['SMTN'] %}
+          {% include "_project-tile.jinja" %}
+        {% endfor %}
+      </div>
+    </section>
+
   </section>
 </body>
 

--- a/wwwlsstio/views/homepage.py
+++ b/wwwlsstio/views/homepage.py
@@ -12,9 +12,16 @@ from . import view_blueprint
 @view_blueprint.route('/', methods=['GET'])
 def get_homepage():
     """Homepage view."""
+    from ..mongo import get_mongo
+
     demo_data_path = os.path.join(os.path.dirname(__file__),
                                   '../data/document-demo.yaml')
     with open(demo_data_path) as f:
         demo_data = yaml.load(f)
+
+    mongo_client = get_mongo()
+    collection = mongo_client['lsstprojectmeta']['resources']
+    n_docs = collection.find({}).count()
+    print('Queried {:d} docs'.format(n_docs))
 
     return render_template('homepage.jinja', data=demo_data)

--- a/wwwlsstio/views/homepage.py
+++ b/wwwlsstio/views/homepage.py
@@ -1,10 +1,8 @@
 """Homepage view.
 """
 
-import os
-
 from flask import render_template
-import yaml
+import pymongo
 
 from . import view_blueprint
 
@@ -14,14 +12,11 @@ def get_homepage():
     """Homepage view."""
     from ..mongo import get_mongo
 
-    demo_data_path = os.path.join(os.path.dirname(__file__),
-                                  '../data/document-demo.yaml')
-    with open(demo_data_path) as f:
-        demo_data = yaml.load(f)
-
     mongo_client = get_mongo()
     collection = mongo_client['lsstprojectmeta']['resources']
-    n_docs = collection.find({}).count()
-    print('Queried {:d} docs'.format(n_docs))
+    query = {'data.reportNumber': {'$regex': r'^SQR-'}}
+    cursor = collection.find(query)\
+        .sort('data.reportNumber', pymongo.DESCENDING)
+    data = [doc['data'] for doc in cursor]
 
-    return render_template('homepage.jinja', data=demo_data)
+    return render_template('homepage.jinja', data=data)

--- a/wwwlsstio/views/homepage.py
+++ b/wwwlsstio/views/homepage.py
@@ -14,9 +14,17 @@ def get_homepage():
 
     mongo_client = get_mongo()
     collection = mongo_client['lsstprojectmeta']['resources']
-    query = {'data.reportNumber': {'$regex': r'^SQR-'}}
-    cursor = collection.find(query)\
-        .sort('data.reportNumber', pymongo.DESCENDING)
-    data = [doc['data'] for doc in cursor]
 
-    return render_template('homepage.jinja', data=data)
+    queries = {
+        'SQR': {'data.reportNumber': {'$regex': r'^SQR-'}},
+        'DMTN': {'data.reportNumber': {'$regex': r'^DMTN-'}},
+        'SMTN': {'data.reportNumber': {'$regex': r'^SMTN-'}},
+    }
+
+    datasets = {}
+    for series, query in queries.items():
+        cursor = collection.find(query)\
+            .sort('data.reportNumber', pymongo.DESCENDING)
+        datasets[series] = [doc['data'] for doc in cursor]
+
+    return render_template('homepage.jinja', datasets=datasets)


### PR DESCRIPTION
- Use the Projectmeta MongoDB to populate the site.
- Refactor the project tile template into a Jinja partial.
- Create Jinja filters for processing display URLs, rendering author lists from JSON-LD nodes, and processing text as markdown into HTML.
- Proof-of-concept homepage that shows the DMTN, SMTN, and SQR technote series.

![screen shot 2018-01-18 at 5 19 26 pm](https://user-images.githubusercontent.com/349384/35128437-c155806e-fc73-11e7-9289-61609a9733ca.png)
