### PR TITLE
DM-16358: Updates for PSTN, LTD Conveyor, and date updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,4 @@ site:
 	FLASK_APP=wwwlsstio:app flask build
 
 deploy:
-	LTD_KEEPER_URL=https://keeper.lsst.codes LTD_MASON_PRODUCT=www LTD_MASON_BUILD=true TRAVIS_PULL_REQUEST=false TRAVIS_REPO_SLUG=lsst-sqre/ltd-mason TRAVIS_BRANCH=master ltd-mason-travis --html-dir _build
+	ltd upload --product=www  --git-ref=master --dir _build

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'PyYAML==3.12',
         'pymongo==3.6.0',
         'misaka==2.1.0',
-        'ltd-mason==0.2.5'
+        'ltd-conveyor>=0.4.2,<0.5.0'
     ],
     extras_require={},
     entry_points={

--- a/wwwlsstio/templates/homepage.jinja
+++ b/wwwlsstio/templates/homepage.jinja
@@ -15,6 +15,8 @@
   <main class="o-wrapper">
     <h1>LSST Documentation Hub</h1>
 
+    <p>The Documentation Hub is a service in preview by LSST SQuaRE. Updated on {{ date_updated }}.</p>
+
     <nav>
       <h2>On this page</h2>
       <ul>

--- a/wwwlsstio/templates/homepage.jinja
+++ b/wwwlsstio/templates/homepage.jinja
@@ -20,6 +20,7 @@
       <ul>
         <li><a href="#lpm">LSST Project Management (LPM)</a></li>
         <li><a href="#lse">LSST Systems Engineering (LSE)</a></li>
+        <li><a href="#pstn">LSST Project Science Team Technical Notes (PSTN)</a></li>
         <li><a href="#ldm">LSST Data Management (LDM)</a></li>
         <li><a href="#dmtr">LSST Data Management Test Reports (DMTR)</a></li>
         <li><a href="#dmtn">LSST Data Management Technical Notes (DMTN)</a></li>
@@ -49,6 +50,19 @@
         {% set current_header_level = 3 %}
 
         {% for item in datasets['LSE'] %}
+          {% include "_project-tile.jinja" %}
+        {% endfor %}
+      </div>
+    </section>
+
+    <section id="pstn" class="c-tile-section">
+      <h2>LSST Project Science Team Technical Notes</h2>
+
+      <div class="c-project-tile-grid">
+        {# Set header level used for project tiles #}
+        {% set current_header_level = 3 %}
+
+        {% for item in datasets['PSTN'] %}
           {% include "_project-tile.jinja" %}
         {% endfor %}
       </div>

--- a/wwwlsstio/views/homepage.py
+++ b/wwwlsstio/views/homepage.py
@@ -23,6 +23,7 @@ def get_homepage():
         'LSE': {'data.reportNumber': {'$regex': r'^LSE-'}},
         'LPM': {'data.reportNumber': {'$regex': r'^LPM-'}},
         'DMTR': {'data.reportNumber': {'$regex': r'^DMTR-'}},
+        'PSTN': {'data.reportNumber': {'$regex': r'^PSTN-'}},
     }
 
     datasets = {}
@@ -30,5 +31,6 @@ def get_homepage():
         cursor = collection.find(query)\
             .sort('data.reportNumber', pymongo.DESCENDING)
         datasets[series] = [doc['data'] for doc in cursor]
+        print('Series {0} {1:d} docs'.format(series, len(datasets[series])))
 
     return render_template('homepage.jinja', datasets=datasets)

--- a/wwwlsstio/views/homepage.py
+++ b/wwwlsstio/views/homepage.py
@@ -1,6 +1,8 @@
 """Homepage view.
 """
 
+import datetime
+
 from flask import render_template
 import pymongo
 
@@ -33,4 +35,12 @@ def get_homepage():
         datasets[series] = [doc['data'] for doc in cursor]
         print('Series {0} {1:d} docs'.format(series, len(datasets[series])))
 
-    return render_template('homepage.jinja', datasets=datasets)
+    date = datetime.datetime.now()
+    date_updated = '{month} {day:d}, {year:d}'.format(
+        month=date.strftime('%B'),
+        day=date.day,
+        year=date.year)
+
+    return render_template(
+        'homepage.jinja', datasets=datasets,
+        date_updated=date_updated)


### PR DESCRIPTION
Various small updates:

- Now using https://github.com/lsst-sqre/ltd-conveyor for deployment. LTD Mason is largely deprecated and doesn't build with Python 3.7 due to dependencies.

- Add support for PSTNs

- Add the "date updated" to the page.