### PR TITLE
DM-24582: Use HierarchicalMenu for content type refinement

### DIFF
--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -4,6 +4,7 @@ import {
   InstantSearch,
   Configure,
   RefinementList,
+  HierarchicalMenu,
 } from 'react-instantsearch-dom';
 
 import Layout from '../components/layout';
@@ -54,8 +55,13 @@ const AdvancedSearchPage = () => {
 
           <SearchRefinementsArea>
             <SearchRefinementSection>
-              <h2>Series</h2>
-              <RefinementList attribute="series" />
+              <h2>Content types</h2>
+              <HierarchicalMenu
+                attributes={[
+                  'contentCategories.lvl0',
+                  'contentCategories.lvl1',
+                ]}
+              />
             </SearchRefinementSection>
 
             <SearchRefinementSection>


### PR DESCRIPTION
On the Advanced search page we can have all types of content. It therefore makes sense to use a hierarchical refinement to let a use provide specificity on what type of content they'd like to see.

This works with the "contentCategories.lxlX" record field added in DM-24241. https://github.com/lsst-sqre/ook/pull/2

Note that these record attributes need to be maked as attributes for faceting in the Algolia config UI.

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/349384/80142621-7d6c2d80-8579-11ea-8ab4-8ea6ba1bd5e6.png">
