### PR TITLE
DM-24955: Always use trailing slash in links

### DIFF
--- a/src/components/heroSearchForm.js
+++ b/src/components/heroSearchForm.js
@@ -31,7 +31,7 @@ export default function HeroSearchForm() {
 
   const handleSubmit = e => {
     e.preventDefault(); // don't reload page on submission
-    navigate(`/search?query=${query}`, { replace: false });
+    navigate(`/search/?query=${query}`, { replace: false });
   };
 
   return (


### PR DESCRIPTION
Gatsby Link natively prefers adding trailing slashes, see
https://zenofreact.com/why-the-trailing-slash-gatsby/

This is also easier for Fastly/LSST the Docs configuration to handle.

In conjunction with the Fastly Varnish configuration update described in [DM-24955](https://jira.lsstcorp.org/browse/DM-24955), this update ensures that a user can request a URL that includes the query string created by the app. 