### PR TITLE
DM-25690: Add browsable category pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://github.com/lsst-sqre/www_lsst_io/workflows/CI/badge.svg
+   :target: https://github.com/lsst-sqre/www_lsst_io/actions?query=workflow%3ACI
+
 ###########
 www.lsst.io
 ###########
@@ -5,10 +8,15 @@ www.lsst.io
 https://www.lsst.io is a portal for `Rubin Observatory`_ documentation.
 It's designed to help Rubin Observatory staff and the astronomy community discover documentation, software, and other bits of information produced by the Rubin Observatory and LSST.
 
-This site is built with Gatsby_ and React_.
-The search experience is powered by Algolia_.
-It's deployed on `LSST the Docs <https://sqr-006.lsst.io>`__.
-Searchable content is curated and ingested by Ook_, the Rubin Observatory librarian service.
+Technical stack
+===============
+
+- This site is built with Gatsby_ and React_.
+- The search experience is powered by Algolia_ and react-instantsearch_
+- Styling is done through styled-components_.
+- It's deployed on `LSST the Docs <https://sqr-006.lsst.io>`__.
+- Searchable content is curated and ingested by Ook_, the Rubin Observatory librarian service.
+  Ook ingests URLs/documents on-demand through a Kafka message queue on Roundtable_.
 
 Development workflow primer
 ===========================
@@ -141,6 +149,9 @@ Here are the important files and directories:
 .. _Gatsby: https://www.gatsbyjs.org
 .. _React: https://reactjs.org
 .. _Algolia: https://www.algolia.com
+.. _react-instantsearch: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/
+.. _styled-components: https://styled-components.com
 .. _Ook: https://github.com/lsst-sqre/ook
 .. _Prettier: https://prettier.io/
 .. _pre-commit: https://pre-commit.com/
+.. _Roundtable: https://roundtable.lsst.io

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,18 +7,66 @@
 exports.createPages = ({ actions }) => {
   const { createPage } = actions;
 
-  const allDocSeries = [
+  const docSeriesCategories = [
+    {
+      key: 'DMTN',
+      name: 'Data Management Technotes',
+    },
+    {
+      key: 'DMTR',
+      name: 'Data Management Test Reports',
+    },
+    {
+      key: 'ITTN',
+      name: 'IT Technotes',
+    },
+    {
+      key: 'ITTN',
+      name: 'IT Technotes',
+    },
+    {
+      key: 'LDM',
+      name: 'LSST Data Management',
+    },
+    {
+      key: 'LPM',
+      name: 'LSST Project Management',
+    },
+    {
+      key: 'LSE',
+      name: 'LSST Systems Engineering',
+    },
+    {
+      key: 'OPSTN',
+      name: 'Operations Technotes',
+    },
+    {
+      key: 'PSTN',
+      name: 'Project Science Team Technotes',
+    },
+    {
+      key: 'RTN',
+      name: 'Rubin Technotes',
+    },
+    {
+      key: 'SMTN',
+      name: 'Simulations Technotes',
+    },
+    {
+      key: 'SITCOMTN',
+      name: 'Systems Integration, Testing, and Commissioning Technotes',
+    },
     {
       key: 'SQR',
       name: 'SQuaRE Technotes',
     },
     {
-      key: 'DMTN',
-      name: 'Data Management Technotes',
+      key: 'TSTN',
+      name: 'Telescope & Site Technotes',
     },
   ];
 
-  allDocSeries.forEach(docSeries => {
+  docSeriesCategories.forEach(docSeries => {
     createPage({
       path: `/${docSeries.key.toLowerCase()}/`,
       component: require.resolve(`./src/templates/docSeries.js`),

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,7 +20,7 @@ exports.createPages = ({ actions }) => {
 
   allDocSeries.forEach(docSeries => {
     createPage({
-      path: `/${docSeries.key.toLowerCase()}`,
+      path: `/${docSeries.key.toLowerCase()}/`,
       component: require.resolve(`./src/templates/docSeries.js`),
       context: { docSeries },
     });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,4 +4,25 @@
  * See: https://www.gatsbyjs.org/docs/node-apis/
  */
 
-// You can delete this file if you're not using it
+exports.createPages = ({ actions }) => {
+  const { createPage } = actions;
+
+  const allDocSeries = [
+    {
+      key: 'SQR',
+      name: 'SQuaRE Technotes',
+    },
+    {
+      key: 'DMTN',
+      name: 'Data Management Technotes',
+    },
+  ];
+
+  allDocSeries.forEach(docSeries => {
+    createPage({
+      path: `/${docSeries.key.toLowerCase()}`,
+      component: require.resolve(`./src/templates/docSeries.js`),
+      context: { docSeries },
+    });
+  });
+};

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -18,9 +18,39 @@ const StyledFooter = styled.footer`
   }
 `;
 
+const FeedbackContainer = styled.section`
+  margin-bottom: 4rem;
+
+  h2 {
+    font-size: 1rem;
+  }
+`;
+
 const Footer = () => (
   <StyledFooter>
     <PageContentContainer>
+      <FeedbackContainer>
+        <h2>Have feedback?</h2>
+        <p>There are many ways to get in touch:</p>
+        <ul>
+          <li>
+            <a href="https://github.com/lsst-sqre/www_lsst_io/issues/new">
+              Create a GitHub issue
+            </a>
+          </li>
+          <li>
+            <a href="https://jira.lsstcorp.org/issues/?jql=project+%3D+DM+AND+component+%3D+www_lsst_io">
+              Create a Jira ticket in the <code>www_lsst_io</code> component
+              (internal)
+            </a>
+          </li>
+          <li>
+            <a href="slack://channel?team=T06D204F2&id=C2B6DQBAL">
+              Chat in #dm-docs on Slack (internal)
+            </a>
+          </li>
+        </ul>
+      </FeedbackContainer>
       <p>
         © {new Date().getFullYear()} Association of Universities for Research in
         Astronomy (AURA), Inc.

--- a/src/components/instantsearch/autoSortBy.js
+++ b/src/components/instantsearch/autoSortBy.js
@@ -1,0 +1,47 @@
+/*
+ * "Auto" version of the SortBy component that toggles to a relevance-based
+ * search whenever the user enters a query string.
+ *
+ * This component uses the StateResults instantsearch widget
+ * (https://www.algolia.com/doc/api-reference/widgets/state-results/react/)
+ * StateResults gives us access to the query string. If the user sets a
+ * value for the query string we change the defaultRefinement attribute of
+ * the underlying SortBy component. When no query string is present we use
+ * "defaultRefinement", which is the name of a sorted index. If a query string
+ * is present, we switch to the relevance-based index so that results are
+ * orderd most naturally.
+ *
+ * Note that so long as the user doesn't interact with the AutoSortBy widget,
+ * the selection will revert back to the sorted index if the user deletes
+ * the query text.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { connectStateResults } from 'react-instantsearch-dom';
+import SortBy from './sortBy';
+
+const AutoSortByCore = ({
+  searchState,
+  items,
+  defaultRefinement,
+  relevanceRefinement,
+}) => {
+  const currentRefinement = searchState.query
+    ? relevanceRefinement
+    : defaultRefinement;
+
+  return <SortBy defaultRefinement={currentRefinement} items={items} />;
+};
+
+AutoSortByCore.propTypes = {
+  searchState: PropTypes.object,
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  defaultRefinement: PropTypes.string,
+  relevanceRefinement: PropTypes.string,
+};
+
+const AutoSortBy = connectStateResults(AutoSortByCore);
+
+export default AutoSortBy;

--- a/src/components/instantsearch/nonEmptyHits.js
+++ b/src/components/instantsearch/nonEmptyHits.js
@@ -1,0 +1,34 @@
+/*
+ * Custom Hits component that only displays Hits if a query string is provided.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { connectStateResults } from 'react-instantsearch-dom';
+import { StyledHits } from '../hits';
+
+const NonEmptyHitsCore = ({ searchState, hitComponent, hitCardsExpanded }) => {
+  console.log(`NonEmptyHitsCore ${searchState.query}`);
+
+  return searchState && searchState.query ? (
+    <StyledHits
+      hitComponent={hitComponent}
+      hitCardsExpanded={hitCardsExpanded}
+    />
+  ) : (
+    <div>
+      <p>Type in a search term&hellip;</p>
+    </div>
+  );
+};
+
+NonEmptyHitsCore.propTypes = {
+  searchState: PropTypes.object,
+  hitComponent: PropTypes.func.isRequired,
+  hitCardsExpanded: PropTypes.bool,
+};
+
+const NonEmptyHits = connectStateResults(NonEmptyHitsCore);
+
+export default NonEmptyHits;

--- a/src/components/instantsearch/sortBy.js
+++ b/src/components/instantsearch/sortBy.js
@@ -6,15 +6,52 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-// import styled from 'styled-components';
-// import theme from 'styled-theming';
+import styled from 'styled-components';
 import { connectSortBy } from 'react-instantsearch-dom';
 
+import { primary, neutral } from '../../design/color';
+import elevations from '../../design/elevations';
+
+const Label = styled.span`
+  margin-right: 0.5em;
+`;
+
+/*
+ * See https://www.filamentgroup.com/lab/select-css.html for background
+ * on styling select elements.
+ */
+const Select = styled.select`
+  display: inline-block;
+  width: auto;
+  max-width: 100%;
+  color: ${neutral['100']};
+  background-color: ${primary['900']};
+  background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%${neutral[
+    '100'
+  ].replace(
+    /^#/,
+    ''
+  )}%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+    linear-gradient(to bottom, ${primary['800']} 100%, ${primary['800']} 100%);
+  background-repeat: no-repeat, repeat;
+  background-position: right 0.7em top 50%, 0 0;
+  background-size: 0.65em auto, 100%;
+  appearance: none;
+  padding: 5px 20px;
+  padding-right: 2em;
+  border-radius: 4px;
+  font-size: 1em;
+  border: none;
+  ${elevations[1]};
+`;
+
+/* eslint-disable */
+/* For jsx-a11y/label-has-for doesn't recognize the custom Select */
 const SortByCore = ({ items, currentRefinement, refine }) => (
   <>
     <label htmlFor="search-sortby">
-      <span>Sort by</span>
-      <select
+      <Label>Sort by</Label>
+      <Select
         id="search-sortby"
         onChange={e => {
           refine(e.target.value);
@@ -29,10 +66,11 @@ const SortByCore = ({ items, currentRefinement, refine }) => (
             {item.label}
           </option>
         ))}
-      </select>
+      </Select>
     </label>
   </>
 );
+/* eslint-enable */
 
 SortByCore.propTypes = {
   items: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/src/components/instantsearch/sortBy.js
+++ b/src/components/instantsearch/sortBy.js
@@ -1,0 +1,46 @@
+/*
+ * Styled version of the SortBy Algolia InstantSearch component.
+ *
+ * https://www.algolia.com/doc/api-reference/widgets/sort-by/react/
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+// import styled from 'styled-components';
+// import theme from 'styled-theming';
+import { connectSortBy } from 'react-instantsearch-dom';
+
+const SortByCore = ({ items, currentRefinement, refine }) => (
+  <>
+    <label htmlFor="search-sortby">
+      <span>Sort by</span>
+      <select
+        id="search-sortby"
+        onChange={e => {
+          refine(e.target.value);
+        }}
+        value={currentRefinement}
+      >
+        {items.map(item => (
+          <option
+            value={item.value}
+            selected={currentRefinement === item.value}
+          >
+            {item.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  </>
+);
+
+SortByCore.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  currentRefinement: PropTypes.string,
+  refine: PropTypes.func,
+  // createURL: PropTypes.func,
+};
+
+const SortBy = connectSortBy(SortByCore);
+
+export default SortBy;

--- a/src/components/searchLayout.js
+++ b/src/components/searchLayout.js
@@ -6,7 +6,7 @@ import { SearchBox } from 'react-instantsearch-dom';
 export const SearchLayout = styled.div`
   display: grid;
   grid-template-columns: 16rem 1fr;
-  grid-template-rows: auto auto;
+  grid-template-rows: auto 1fr;
   grid-column-gap: 2rem;
   grid-row-gap: 2rem;
   margin-top: 2rem;

--- a/src/components/searchSettingsCluster.js
+++ b/src/components/searchSettingsCluster.js
@@ -13,14 +13,22 @@ const StyledCluster = styled(Cluster)`
   overflow: visible; // so the box-shadow isn't being cut off
 `;
 
-const SearchSettingsCluster = ({ children }) => (
-  <StyledCluster space="1rem" justifyContent="flex-end">
+const SearchSettingsCluster = ({ children, justifyContent = 'flex-start' }) => (
+  <StyledCluster space="1rem" justifyContent={`${justifyContent}`}>
     {children}
   </StyledCluster>
 );
 
 SearchSettingsCluster.propTypes = {
   children: PropTypes.node.isRequired,
+  justifyContent: PropTypes.oneOf([
+    'flex-start',
+    'flex-end',
+    'center',
+    'space-between',
+    'space-around',
+    'space-evenly',
+  ]),
 };
 
 export default SearchSettingsCluster;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -109,8 +109,69 @@ const IndexPage = () => (
 
       <ul>
         <li>
+          <Link to="/dmtn/">
+            <strong>DMTN</strong> &mdash; Data Management Technotes
+          </Link>
+        </li>
+        <li>
+          <Link to="/dmtr/">
+            <strong>DMTR</strong> &mdash; Data Management Test Reports
+          </Link>
+        </li>
+        <li>
+          <Link to="/ittn/">
+            <strong>ITTN</strong> &mdash; IT Technotes
+          </Link>
+        </li>
+        <li>
+          <Link to="/ldm/">
+            <strong>LDM</strong> &mdash; LSST Data Management
+          </Link>
+        </li>
+        <li>
+          <Link to="/lpm/">
+            <strong>LPM</strong> &mdash; LSST Project Management
+          </Link>
+        </li>
+        <li>
+          <Link to="/lse/">
+            <strong>LSE</strong> &mdash; LSST Systems Engineering
+          </Link>
+        </li>
+        <li>
+          <Link to="/opstn/">
+            <strong>OPSTN</strong> &mdash; Operations Technotes
+          </Link>
+        </li>
+        <li>
+          <Link to="/pstn/">
+            <strong>PSTN</strong> &mdash; Project Science Team Technotes
+          </Link>
+        </li>
+        <li>
+          <Link to="/rtn/">
+            <strong>RTN</strong> &mdash; Rubin Technotes
+          </Link>
+        </li>
+        <li>
+          <Link to="/smtn/">
+            <strong>SMTN</strong> &mdash; Simulations Technotes
+          </Link>
+        </li>
+        <li>
+          <Link to="/sitcomtn/">
+            <strong>SITCOMTN</strong> &mdash; Systems Integration, Testing, and
+            Commissioning Technotes
+          </Link>
+        </li>
+        <li>
           <Link to="/sqr/">
-            <strong>SQR</strong> &mdash; SQuaRE Technical Notes
+            <strong>SQR</strong> &mdash; SQuaRE Technotes
+          </Link>
+        </li>
+        <li>
+          <Link to="/tstn/">
+            <strong>TSTN</strong> &mdash; Telescope &amp; Site Technotes
           </Link>
         </li>
       </ul>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { graphql, StaticQuery } from 'gatsby';
+import { graphql, StaticQuery, Link } from 'gatsby';
 import BackgroundImage from 'gatsby-background-image';
 import styled from 'styled-components';
 
@@ -97,6 +97,24 @@ const IndexPage = () => (
         </div>
       </StyledSearchContainer>
     </StyledBackgroundSection>
+    <section>
+      <h2>Documents</h2>
+
+      <p>
+        <Link to="/search/?hierarchicalMenu[contentCategories.lvl0]=Documents">
+          Search in all Rubin Observatory documents,
+        </Link>{' '}
+        or browse by series:
+      </p>
+
+      <ul>
+        <li>
+          <Link to="/sqr/">
+            <strong>SQR</strong> &mdash; SQuaRE Technical Notes
+          </Link>
+        </li>
+      </ul>
+    </section>
   </Layout>
 );
 

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -131,11 +131,11 @@ const AdvancedSearchPage = ({ location }) => {
           <SearchResultsArea>
             <SearchSettingsCluster>
               <div>
-                <ClearRefinements />
                 <DetailsToggleButton
                   hitCardsExpanded={hitCardsExpanded}
                   setHitCardsExpanded={setHitCardsExpanded}
                 />
+                <ClearRefinements />
               </div>
             </SearchSettingsCluster>
             <StyledHits

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -21,7 +21,7 @@ import PoweredBy from '../components/instantsearch/poweredBy';
 import RefinementList from '../components/instantsearch/refinementList';
 import HierarchicalMenu from '../components/instantsearch/hierarchicalMenu';
 import ClearRefinements from '../components/instantsearch/clearRefinements';
-import { StyledHits } from '../components/hits';
+import NonEmptyHits from '../components/instantsearch/nonEmptyHits';
 import DetailsToggleButton from '../components/detailsToggle';
 import SearchSettingsCluster from '../components/searchSettingsCluster';
 
@@ -138,7 +138,7 @@ const AdvancedSearchPage = ({ location }) => {
                 <ClearRefinements />
               </div>
             </SearchSettingsCluster>
-            <StyledHits
+            <NonEmptyHits
               hitComponent={DocumentHit}
               hitCardsExpanded={hitCardsExpanded}
             />

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -1,0 +1,22 @@
+/**
+ * Template for a browsable listing of documents within a document series.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+
+export default function DocSeriesTemplate({ pageContext: { docSeries } }) {
+  return (
+    <Layout>
+      <SEO title={docSeries.name} />
+      <h1>{docSeries.name}</h1>
+    </Layout>
+  );
+}
+
+DocSeriesTemplate.propTypes = {
+  pageContext: PropTypes.object.isRequired,
+};

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -27,7 +27,7 @@ import ClearRefinements from '../components/instantsearch/clearRefinements';
 import { StyledHits } from '../components/hits';
 import DetailsToggleButton from '../components/detailsToggle';
 import SearchSettingsCluster from '../components/searchSettingsCluster';
-import SortBy from '../components/instantsearch/sortBy';
+import AutoSortBy from '../components/instantsearch/autoSortBy';
 
 const searchClient = algoliasearch(
   '0OJETYIVL5',
@@ -125,8 +125,9 @@ export default function DocSeriesTemplate({
           <SearchResultsArea>
             <SearchSettingsCluster>
               <div>
-                <SortBy
+                <AutoSortBy
                   defaultRefinement="document_dev_handle_desc"
+                  relevanceRefinement="document_dev"
                   items={[
                     { value: 'document_dev', label: 'Relevance' },
                     { value: 'document_dev_handle_desc', label: 'ID' },

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -125,11 +125,6 @@ export default function DocSeriesTemplate({
           <SearchResultsArea>
             <SearchSettingsCluster>
               <div>
-                <ClearRefinements />
-                <DetailsToggleButton
-                  hitCardsExpanded={hitCardsExpanded}
-                  setHitCardsExpanded={setHitCardsExpanded}
-                />
                 <SortBy
                   defaultRefinement="document_dev_handle_desc"
                   items={[
@@ -137,8 +132,14 @@ export default function DocSeriesTemplate({
                     { value: 'document_dev_handle_desc', label: 'ID' },
                   ]}
                 />
+                <DetailsToggleButton
+                  hitCardsExpanded={hitCardsExpanded}
+                  setHitCardsExpanded={setHitCardsExpanded}
+                />
+                <ClearRefinements />
               </div>
             </SearchSettingsCluster>
+
             <StyledHits
               hitComponent={DocumentHit}
               hitCardsExpanded={hitCardsExpanded}

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -4,19 +4,145 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import algoliasearch from 'algoliasearch/lite';
+import { InstantSearch, Configure } from 'react-instantsearch-dom';
+import qs from 'qs';
+
+import useDebounce from '../hooks/useDebounce';
 
 import Layout from '../components/layout';
 import SEO from '../components/seo';
+import DocumentHit from '../components/documentHit';
+import {
+  SearchLayout,
+  SearchResultsArea,
+  SearchBoxArea,
+  SearchRefinementsArea,
+  StyledSearchBox,
+  SearchRefinementSection,
+} from '../components/searchLayout';
+import PoweredBy from '../components/instantsearch/poweredBy';
+import RefinementList from '../components/instantsearch/refinementList';
+import ClearRefinements from '../components/instantsearch/clearRefinements';
+import { StyledHits } from '../components/hits';
+import DetailsToggleButton from '../components/detailsToggle';
+import SearchSettingsCluster from '../components/searchSettingsCluster';
 
-export default function DocSeriesTemplate({ pageContext: { docSeries } }) {
+const searchClient = algoliasearch(
+  '0OJETYIVL5',
+  'b7bd2f1080a5c4fe5eee502462bcc9d3'
+);
+
+/**
+ * Create the URL parameters from the state.
+ */
+const createUrlParams = state => `?${qs.stringify(state)}`;
+
+/**
+ * Create a full URL from the search state.
+ */
+const searchStateToUrl = ({ location }, searchState) =>
+  searchState ? `${location.pathname}${createUrlParams(searchState)}` : '';
+
+/**
+ * Parse the search state from a URL.
+ */
+const urlToSearchState = ({ search }) => qs.parse(search.slice(1));
+
+/**
+ * Debounce time to update browser history given user input into search UI
+ * (milliseconds).
+ */
+const DEBOUNCE_TIME = 800;
+
+export default function DocSeriesTemplate({
+  pageContext: { docSeries },
+  location,
+}) {
+  const [hitCardsExpanded, setHitCardsExpanded] = React.useState(false);
+  const [searchState, setSearchState] = React.useState(
+    urlToSearchState(location)
+  );
+  const debouncedSearchState = useDebounce(searchState, DEBOUNCE_TIME);
+
+  const onSearchStateChange = updatedSearchState => {
+    setSearchState(updatedSearchState);
+  };
+
+  // Prettier struggles with this useEffect but I don't know why.
+  // prettier-ignore
+  React.useEffect(
+    () => {
+      if (debouncedSearchState) {
+        // I tried using setState here, but I found that that broke the "Back"
+        // button. Ultimately this means that the search state overwrites
+        // itself as the user refines their search. There is no "undo" to the
+        // refinements.
+        window.history.replaceState(
+          debouncedSearchState,
+          '',
+          searchStateToUrl({ location }, debouncedSearchState)
+        );
+      }
+    },
+    [debouncedSearchState, location]
+  );
+
   return (
     <Layout>
       <SEO title={docSeries.name} />
       <h1>{docSeries.name}</h1>
+
+      <InstantSearch
+        searchClient={searchClient}
+        indexName="document_dev"
+        searchState={searchState}
+        onSearchStateChange={onSearchStateChange}
+        createUrl={createUrlParams}
+      >
+        <Configure
+          distinct
+          facetingAfterDistinct
+          attributesToSnippet={['content:20']}
+          filters={`series:${docSeries.key}`}
+          hitsPerPage={1000}
+        />
+
+        <SearchLayout>
+          <SearchBoxArea>
+            <StyledSearchBox autoFocus />
+            <PoweredBy />
+          </SearchBoxArea>
+
+          <SearchRefinementsArea>
+            <SearchRefinementSection>
+              <h2>Contributors</h2>
+              <RefinementList attribute="authorNames" />
+            </SearchRefinementSection>
+          </SearchRefinementsArea>
+
+          <SearchResultsArea>
+            <SearchSettingsCluster>
+              <div>
+                <ClearRefinements />
+                <DetailsToggleButton
+                  hitCardsExpanded={hitCardsExpanded}
+                  setHitCardsExpanded={setHitCardsExpanded}
+                />
+              </div>
+            </SearchSettingsCluster>
+            <StyledHits
+              hitComponent={DocumentHit}
+              hitCardsExpanded={hitCardsExpanded}
+            />
+          </SearchResultsArea>
+        </SearchLayout>
+      </InstantSearch>
     </Layout>
   );
 }
 
 DocSeriesTemplate.propTypes = {
   pageContext: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
 };

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import algoliasearch from 'algoliasearch/lite';
-import { InstantSearch, Configure, SortBy } from 'react-instantsearch-dom';
+import { InstantSearch, Configure } from 'react-instantsearch-dom';
 import qs from 'qs';
 
 import useDebounce from '../hooks/useDebounce';
@@ -27,6 +27,7 @@ import ClearRefinements from '../components/instantsearch/clearRefinements';
 import { StyledHits } from '../components/hits';
 import DetailsToggleButton from '../components/detailsToggle';
 import SearchSettingsCluster from '../components/searchSettingsCluster';
+import SortBy from '../components/instantsearch/sortBy';
 
 const searchClient = algoliasearch(
   '0OJETYIVL5',

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import algoliasearch from 'algoliasearch/lite';
-import { InstantSearch, Configure } from 'react-instantsearch-dom';
+import { InstantSearch, Configure, SortBy } from 'react-instantsearch-dom';
 import qs from 'qs';
 
 import useDebounce from '../hooks/useDebounce';
@@ -95,7 +95,7 @@ export default function DocSeriesTemplate({
 
       <InstantSearch
         searchClient={searchClient}
-        indexName="document_dev"
+        indexName="document_dev_handle_desc"
         searchState={searchState}
         onSearchStateChange={onSearchStateChange}
         createUrl={createUrlParams}
@@ -128,6 +128,13 @@ export default function DocSeriesTemplate({
                 <DetailsToggleButton
                   hitCardsExpanded={hitCardsExpanded}
                   setHitCardsExpanded={setHitCardsExpanded}
+                />
+                <SortBy
+                  defaultRefinement="document_dev_handle_desc"
+                  items={[
+                    { value: 'document_dev', label: 'Relevance' },
+                    { value: 'document_dev_handle_desc', label: 'ID' },
+                  ]}
                 />
               </div>
             </SearchSettingsCluster>


### PR DESCRIPTION
- We're now generating category-specific pages for browsing individual document series, such as `/sqr/` for SQR technotes, and so on. These category pages use the Algolia search interface, but unlike the advanced search page (`/search/`) they sort records. For example, documents are sorted by their handle in descending order.

   When the user starts typing a query term, though, we immediately switch the sorting to a relevance-based order because that provides the best search experience. This is implemented through a customized `SortBy` widget that connects to the `SearchState` widget. This `AutoSortBy` widget sets the default value of the underlying `<select>` element, so the user can still override the sorting and have that choice persist if the query text is deleted, for example.

- Re-ordered the controls in the `SearchSettingsCluster` to make space for a refinement list in the future to extend from the "clear all refinements" control.

- The advanced search page no longer shows any results if the user hasn't entered a query yet (using the new `NonEmptyHits` component). This is appropriate because the advanced search page always sorts by relevance, but relevance is only meaningful if there is a query.

- Category pages are now linked from the homepage.

- In the footer, we now prompt for feedback by linking to different venues (some internal, some accessible to the community).

**The category listing on the homepage:**

<img width="1443" alt="image" src="https://user-images.githubusercontent.com/349384/86950030-92d70980-c11d-11ea-8d8d-f8754a864113.png">

**The new category page:**

<img width="1443" alt="image" src="https://user-images.githubusercontent.com/349384/86950069-a4b8ac80-c11d-11ea-949f-13583bcc9691.png">

**The new footer:**

<img width="1443" alt="image" src="https://user-images.githubusercontent.com/349384/86950756-8f904d80-c11e-11ea-9766-36f75fd8e826.png">
