### PR TITLE
DM-25993: Add disclaimers for not including DocuShare content

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -15,6 +15,10 @@ exports.createPages = ({ actions }) => {
     {
       key: 'DMTR',
       name: 'Data Management Test Reports',
+      notice: {
+        __html:
+          'These results do not contain documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a>.',
+      },
     },
     {
       key: 'ITTN',
@@ -27,14 +31,26 @@ exports.createPages = ({ actions }) => {
     {
       key: 'LDM',
       name: 'LSST Data Management',
+      notice: {
+        __html:
+          'These results do not contain documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a>.',
+      },
     },
     {
       key: 'LPM',
       name: 'LSST Project Management',
+      notice: {
+        __html:
+          'These results do not contain documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a>.',
+      },
     },
     {
       key: 'LSE',
       name: 'LSST Systems Engineering',
+      notice: {
+        __html:
+          'These results do not contain documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a>.',
+      },
     },
     {
       key: 'OPSTN',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -115,6 +115,7 @@ const IndexPage = () => (
           <Link to="/dmtr/">
             <strong>DMTR</strong> &mdash; Data Management Test Reports
           </Link>
+          <sup>*</sup>
         </li>
         <li>
           <Link to="/ittn/">
@@ -125,16 +126,19 @@ const IndexPage = () => (
           <Link to="/ldm/">
             <strong>LDM</strong> &mdash; LSST Data Management
           </Link>
+          <sup>*</sup>
         </li>
         <li>
           <Link to="/lpm/">
             <strong>LPM</strong> &mdash; LSST Project Management
           </Link>
+          <sup>*</sup>
         </li>
         <li>
           <Link to="/lse/">
             <strong>LSE</strong> &mdash; LSST Systems Engineering
           </Link>
+          <sup>*</sup>
         </li>
         <li>
           <Link to="/opstn/">
@@ -173,6 +177,16 @@ const IndexPage = () => (
           </Link>
         </li>
       </ul>
+
+      <p>
+        <small>
+          <sup>*</sup> Documents held only in{' '}
+          <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">
+            DocuShare
+          </a>{' '}
+          are not yet part of the search results.
+        </small>
+      </p>
     </section>
   </Layout>
 );

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -94,6 +94,9 @@ export default function DocSeriesTemplate({
       <SEO title={docSeries.name} description={docSeries.description} />
       <h1>{docSeries.name}</h1>
 
+      {/* eslint-disable-next-line react/no-danger */}
+      {docSeries.notice && <p dangerouslySetInnerHTML={docSeries.notice} />}
+
       <InstantSearch
         searchClient={searchClient}
         indexName="document_dev_handle_desc"


### PR DESCRIPTION
At launch, www.lsst.io doesn't cover documents in DocuShare that don't have counterpart versions on LSST the Docs, which we're currently scraping. This ticket is to temporarily add notices to the site to clear this confusion up.