### PR TITLE
DM-25918: List user guides via a static YAML dataset

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -52,5 +52,12 @@ module.exports = {
         policy: [{ userAgent: '*', allow: '/' }],
       },
     },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        path: `${__dirname}/src/data`,
+      },
+    },
+    'gatsby-transformer-yaml',
   ],
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,89 +7,28 @@
 exports.createPages = async function({ actions, graphql }) {
   const { createPage } = actions;
 
-  const docSeriesCategories = [
-    {
-      key: 'DMTN',
-      name: 'Data Management Technotes',
-    },
-    {
-      key: 'DMTR',
-      name: 'Data Management Test Reports',
-      notice: {
-        __html:
-          'Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.',
-      },
-    },
-    {
-      key: 'ITTN',
-      name: 'IT Technotes',
-    },
-    {
-      key: 'ITTN',
-      name: 'IT Technotes',
-    },
-    {
-      key: 'LDM',
-      name: 'LSST Data Management',
-      notice: {
-        __html:
-          'Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.',
-      },
-    },
-    {
-      key: 'LPM',
-      name: 'LSST Project Management',
-      notice: {
-        __html:
-          'Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.',
-      },
-    },
-    {
-      key: 'LSE',
-      name: 'LSST Systems Engineering',
-      notice: {
-        __html:
-          'Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.',
-      },
-    },
-    {
-      key: 'OPSTN',
-      name: 'Operations Technotes',
-    },
-    {
-      key: 'PSTN',
-      name: 'Project Science Team Technotes',
-    },
-    {
-      key: 'RTN',
-      name: 'Rubin Technotes',
-    },
-    {
-      key: 'SMTN',
-      name: 'Simulations Technotes',
-    },
-    {
-      key: 'SITCOMTN',
-      name: 'Systems Integration, Testing, and Commissioning Technotes',
-    },
-    {
-      key: 'SQR',
-      name: 'SQuaRE Technotes',
-    },
-    {
-      key: 'TSTN',
-      name: 'Telescope & Site Technotes',
-    },
-  ];
+  const { data: docSeriesCategories } = await graphql(`
+    query DocSeries {
+      allDocSeriesYaml(sort: { fields: key, order: ASC }) {
+        edges {
+          node {
+            key
+            name
+            notice
+          }
+        }
+      }
+    }
+  `);
 
-  docSeriesCategories.forEach(docSeries => {
+  docSeriesCategories.allDocSeriesYaml.edges.forEach(({ node }) => {
     createPage({
-      path: `/${docSeries.key.toLowerCase()}/`,
+      path: `/${node.key.toLowerCase()}/`,
       component: require.resolve(`./src/templates/docSeries.js`),
       context: {
         docSeries: {
-          ...docSeries,
-          description: `Browse and search Rubin Observatory ${docSeries.key} documents.`,
+          ...node,
+          description: `Browse and search Rubin Observatory ${node.key} documents.`,
         },
       },
     });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,7 +4,7 @@
  * See: https://www.gatsbyjs.org/docs/node-apis/
  */
 
-exports.createPages = ({ actions }) => {
+exports.createPages = async function({ actions, graphql }) {
   const { createPage } = actions;
 
   const docSeriesCategories = [
@@ -91,6 +91,33 @@ exports.createPages = ({ actions }) => {
           ...docSeries,
           description: `Browse and search Rubin Observatory ${docSeries.key} documents.`,
         },
+      },
+    });
+  });
+
+  const { data: userGuideCollectionsData } = await graphql(`
+    query UserGuideCollections {
+      allGuideCollectionsYaml {
+        edges {
+          node {
+            slug
+            title
+            tag
+            description
+          }
+        }
+      }
+    }
+  `);
+  userGuideCollectionsData.allGuideCollectionsYaml.edges.forEach(({ node }) => {
+    const { slug, title, tag, description } = node;
+    actions.createPage({
+      path: `/${slug}/`,
+      component: require.resolve(`./src/templates/guideCollection.js`),
+      context: {
+        title,
+        tag,
+        description,
       },
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7129,6 +7129,11 @@
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
+    "css-selector-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
+      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="
+    },
     "css-selector-tokenizer": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.2.tgz",
@@ -11781,6 +11786,36 @@
           "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "gatsby-transformer-yaml": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-yaml/-/gatsby-transformer-yaml-2.4.10.tgz",
+      "integrity": "sha512-jQwtyIn0pvT1GfmdxKUKgdJwgK/z8aVVN7wFeHuskhDwWzxCghB88ybyhS7gOF0ttyKNYjQIpwgwt9PnL+AJBQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "js-yaml": "^3.14.0",
+        "lodash": "^4.17.15",
+        "unist-util-select": "^1.5.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         }
       }
@@ -20834,6 +20869,16 @@
       "integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
       "requires": {
         "unist-util-visit": "^2.0.0"
+      }
+    },
+    "unist-util-select": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-1.5.0.tgz",
+      "integrity": "sha1-qTwr6MD2U4J4A7gTMa3sKqJM2TM=",
+      "requires": {
+        "css-selector-parser": "^1.1.0",
+        "debug": "^2.2.0",
+        "nth-check": "^1.0.1"
       }
     },
     "unist-util-stringify-position": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gatsby-plugin-styled-components": "^3.3.10",
     "gatsby-source-filesystem": "^2.3.20",
     "gatsby-transformer-sharp": "^2.5.11",
+    "gatsby-transformer-yaml": "^2.4.10",
     "instantsearch.css": "^7.4.2",
     "moment": "^2.27.0",
     "polished": "^3.6.5",

--- a/src/components/basics/grid.js
+++ b/src/components/basics/grid.js
@@ -1,0 +1,30 @@
+/*
+ * A general-purpose grid component based on Grid from every-layout.dev.
+ *
+ * This grid's column count is flexible to the number of items and the minimum
+ * content width. This way it degrades well to a single-column mobile view.
+ */
+
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const Grid = styled.div`
+  display: grid;
+  grid-gap: ${({ gridGap }) => gridGap};
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(min(${({ minWidth }) => minWidth}, 100%), 1fr)
+  );
+`;
+
+Grid.propTypes = {
+  gridGap: PropTypes.string,
+  minWidth: PropTypes.string,
+};
+
+Grid.defaultProps = {
+  gridGap: '1em',
+  minWidth: '250px',
+};
+
+export default Grid;

--- a/src/components/featuredGuides.js
+++ b/src/components/featuredGuides.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { useStaticQuery, graphql } from 'gatsby';
+
+const FeaturedGuides = () => {
+  const data = useStaticQuery(graphql`
+    query FeaturedGuides {
+      allGuidesYaml(
+        filter: { tags: { eq: "editorial/featured" } }
+        sort: { fields: title, order: ASC }
+      ) {
+        edges {
+          node {
+            slug
+            github
+            description
+            title
+          }
+        }
+      }
+    }
+  `);
+  return (
+    <ul>
+      {data.allGuidesYaml.edges.map(({ node }) => (
+        <li key={node.slug}>{node.title}</li>
+      ))}
+    </ul>
+  );
+};
+
+export default FeaturedGuides;

--- a/src/components/featuredGuides.js
+++ b/src/components/featuredGuides.js
@@ -2,6 +2,9 @@ import React from 'react';
 
 import { useStaticQuery, graphql } from 'gatsby';
 
+import Grid from './basics/grid';
+import GuideCard from './guideCard';
+
 const FeaturedGuides = () => {
   const data = useStaticQuery(graphql`
     query FeaturedGuides {
@@ -21,11 +24,17 @@ const FeaturedGuides = () => {
     }
   `);
   return (
-    <ul>
+    <Grid gridGap="1em" minWidth="18em">
       {data.allGuidesYaml.edges.map(({ node }) => (
-        <li key={node.slug}>{node.title}</li>
+        <GuideCard
+          key={node.slug}
+          slug={node.slug}
+          title={node.title}
+          description={node.description}
+          github={node.github}
+        />
       ))}
-    </ul>
+    </Grid>
   );
 };
 

--- a/src/components/featuredGuides.js
+++ b/src/components/featuredGuides.js
@@ -2,8 +2,7 @@ import React from 'react';
 
 import { useStaticQuery, graphql } from 'gatsby';
 
-import Grid from './basics/grid';
-import GuideCard from './guideCard';
+import GuideGrid from './guideGrid';
 
 const FeaturedGuides = () => {
   const data = useStaticQuery(graphql`
@@ -23,19 +22,7 @@ const FeaturedGuides = () => {
       }
     }
   `);
-  return (
-    <Grid gridGap="1em" minWidth="18em">
-      {data.allGuidesYaml.edges.map(({ node }) => (
-        <GuideCard
-          key={node.slug}
-          slug={node.slug}
-          title={node.title}
-          description={node.description}
-          github={node.github}
-        />
-      ))}
-    </Grid>
-  );
+  return <GuideGrid guides={data.allGuidesYaml.edges} />;
 };
 
 export default FeaturedGuides;

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -9,7 +9,7 @@ const StyledFooter = styled.footer`
   background: var(--c-reversed-background);
   color: var(--c-reversed-text);
   flex-shrink: 0;
-  margin-top: var(--space-lg);
+  margin-top: 0;
 
   a {
     color: var(--c-reversed-link);

--- a/src/components/globalStyles.js
+++ b/src/components/globalStyles.js
@@ -146,8 +146,8 @@ const GlobalStyle = createGlobalStyle`
     --c-snippet-border: var(--c-primary);
     --c-icon-primary: var(--c-neutral-200);
     --c-icon-secondary: var(--c-primary);
-    --c-hit-card-background: #FFFFFF;
-    --c-hit-card-border: none;
+    --c-card-background: #FFFFFF;
+    --c-card-border: none;
     --c-algolia-text: #182359;
     --c-table-border: var(--c-primary);
     --c-table-row-highlight: var(--c-neutral-100);
@@ -228,8 +228,8 @@ const GlobalStyle = createGlobalStyle`
     --c-tag-background: var(--c-neutral-700);
     --c-faded-text: var(--c-neutral-400);
     --c-snippet-background: var(--c-neutral-700);
-    --c-hit-card-background: var(--c-neutral-900);
-    --c-hit-card-border: var(--c-neutral-700);
+    --c-card-background: var(--c-neutral-900);
+    --c-card-border: var(--c-neutral-700);
     --c-icon-primary: var(--c-primary);
     --c-icon-secondary: var(--c-neutral-100);
     --c-algolia-text: var(--c-text);

--- a/src/components/globalStyles.js
+++ b/src/components/globalStyles.js
@@ -146,6 +146,8 @@ const GlobalStyle = createGlobalStyle`
     --c-snippet-border: var(--c-primary);
     --c-icon-primary: var(--c-neutral-200);
     --c-icon-secondary: var(--c-primary);
+    --c-card-text: var(--c-text);
+    --c-card-link: var(--c-link);
     --c-card-background: #FFFFFF;
     --c-card-border: none;
     --c-algolia-text: #182359;

--- a/src/components/globalStyles.js
+++ b/src/components/globalStyles.js
@@ -153,6 +153,12 @@ const GlobalStyle = createGlobalStyle`
     --c-algolia-text: #182359;
     --c-table-border: var(--c-primary);
     --c-table-row-highlight: var(--c-neutral-100);
+    --c-brand-layer-background: var(--c-primary);
+    --c-brand-layer-text: var(--c-reversed-text);
+    --c-brand-layer-link: var(--c-reversed-link);
+    --c-alternate-layer-background: var(--c-neutral-800);
+    --c-alternate-layer-text: var(--c-reversed-text);
+    --c-alternate-layer-link: var(--c-reversed-link);
 
     /*
      * Elevations

--- a/src/components/guideCard.js
+++ b/src/components/guideCard.js
@@ -40,6 +40,11 @@ const CardContainer = styled.div`
       text-decoration: underline;
     }
   }
+
+  /* The dl (IconDataList) always appears at the bottom of the card. */
+  dl {
+    margin-bottom: 0;
+  }
 `;
 
 const GuideCard = ({ slug, github, description, title }) => {

--- a/src/components/guideCard.js
+++ b/src/components/guideCard.js
@@ -14,11 +14,11 @@ const StyledCodeIcon = styled(CodeIcon)`
 
   /* secondary and primary look better reversed */
   .secondary {
-    fill: var(--c-icon-primary);
+    fill: var(--c-card-text);
   }
 
   .primary {
-    fill: var(--c-icon-secondary);
+    fill: var(--c-card-background);
   }
 `;
 
@@ -29,6 +29,7 @@ const CardContainer = styled.div`
   background-color: var(--c-card-background);
   border: 1px solid var(--c-card-border);
   border-radius: var(--border-radius-1);
+  color: var(--c-card-text);
 
   h3 {
     line-height: 1.1;
@@ -36,6 +37,7 @@ const CardContainer = styled.div`
   }
 
   a {
+    color: var(--c-card-link);
     text-decoration: none;
 
     &: hover {

--- a/src/components/guideCard.js
+++ b/src/components/guideCard.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+import { IconDataListTerm, IconDataListContent } from './basics/iconDataList';
+import CodeIcon from '../icons/code.svg';
+import VisuallyHidden from './basics/visuallyHidden';
+
+const StyledCodeIcon = styled(CodeIcon)`
+  width: 0.85em;
+  width: 1cap;
+  height: 0.85em;
+  height: 1cap;
+
+  /* secondary and primary look better reversed */
+  .secondary {
+    fill: var(--c-icon-primary);
+  }
+
+  .primary {
+    fill: var(--c-icon-secondary);
+  }
+`;
+
+const CardContainer = styled.div`
+  padding: var(--space-unit);
+  margin: 0;
+  box-shadow: var(--elevation-base);
+  background-color: #ffffff;
+
+  h3 {
+    line-height: 1.1;
+    margin: 0 0 1rem 0;
+  }
+
+  a {
+    text-decoration: none;
+
+    &: hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
+const GuideCard = ({ slug, github, description, title }) => {
+  const siteUrl = `https://${slug}.lsst.io/`;
+  const githubUrl = `https://github.com/${github}`;
+
+  return (
+    <CardContainer>
+      <a href={siteUrl}>
+        <h3>{title}</h3>
+      </a>
+      <p>{description}</p>
+      <dl>
+        <IconDataListTerm>
+          <StyledCodeIcon />
+          <VisuallyHidden>Source repository</VisuallyHidden>
+        </IconDataListTerm>
+        <IconDataListContent>
+          <a href={githubUrl}>{github}</a>
+        </IconDataListContent>
+      </dl>
+    </CardContainer>
+  );
+};
+
+GuideCard.propTypes = {
+  slug: PropTypes.string,
+  github: PropTypes.string,
+  description: PropTypes.string,
+  title: PropTypes.string,
+};
+
+export default GuideCard;

--- a/src/components/guideCard.js
+++ b/src/components/guideCard.js
@@ -26,7 +26,9 @@ const CardContainer = styled.div`
   padding: var(--space-unit);
   margin: 0;
   box-shadow: var(--elevation-base);
-  background-color: #ffffff;
+  background-color: var(--c-card-background);
+  border: 1px solid var(--c-card-border);
+  border-radius: var(--border-radius-1);
 
   h3 {
     line-height: 1.1;

--- a/src/components/guideGrid.js
+++ b/src/components/guideGrid.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Grid from './basics/grid';
+import GuideCard from './guideCard';
+
+const GuideGrid = ({ guides }) => (
+  <Grid gridGap="1em" minWidth="18em">
+    {guides.map(({ node }) => (
+      <GuideCard
+        key={node.slug}
+        slug={node.slug}
+        title={node.title}
+        description={node.description}
+        github={node.github}
+      />
+    ))}
+  </Grid>
+);
+
+GuideGrid.propTypes = {
+  guides: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default GuideGrid;

--- a/src/components/index/backgroundSection.js
+++ b/src/components/index/backgroundSection.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { graphql, StaticQuery } from 'gatsby';
+import BackgroundImage from 'gatsby-background-image';
+import styled from 'styled-components';
+
+import PageContentContainer from '../pageContentContainer';
+
+const BackgroundSection = ({ className, children }) => (
+  <StaticQuery
+    query={graphql`
+      query {
+        desktop: file(relativePath: { eq: "lsst-stills-0014.jpg" }) {
+          childImageSharp {
+            fluid(quality: 90, maxWidth: 1920) {
+              ...GatsbyImageSharpFluid_withWebp
+            }
+          }
+        }
+      }
+    `}
+    render={data => {
+      const imageData = data.desktop.childImageSharp.fluid;
+
+      return (
+        <BackgroundImage
+          Tag="section"
+          className={className}
+          fluid={imageData}
+          backgroundColor="var(--c-reversed-background)"
+        >
+          {children}
+        </BackgroundImage>
+      );
+    }}
+  />
+);
+
+BackgroundSection.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
+
+export const StyledBackgroundSection = styled(BackgroundSection)`
+  // Full-width in a contrained parent
+  // https://css-tricks.com/full-width-containers-limited-width-parents/
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+
+  // Background image
+  background-position: bottom center;
+  background-size: cover;
+
+  // Effectively a "reversed" block; doesn't change based on theme
+  color: var(--c-reversed-text);
+`;
+
+/*
+ * Container for content within the BackgroundSection.
+ *
+ * Using flexbox to center the hero content.
+ */
+export const StyledSearchContainer = styled(PageContentContainer)`
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 70vh; // Give a peak of content down the page
+  }
+
+  .principal {
+    margin-top: auto;
+    margin-bottom: auto;
+  }
+`;

--- a/src/components/index/backgroundSection.js
+++ b/src/components/index/backgroundSection.js
@@ -69,6 +69,7 @@ export const StyledSearchContainer = styled(PageContentContainer)`
     display: flex;
     flex-direction: column;
     height: 70vh; // Give a peak of content down the page
+    max-height: 28em;
   }
 
   .principal {

--- a/src/components/instantsearch/hits.js
+++ b/src/components/instantsearch/hits.js
@@ -61,8 +61,8 @@ export const StyledHits = styled(ConnectedHits)`
     margin-bottom: var(--space-unit);
     padding: var(--space-unit);
     box-shadow: var(--elevation-lg);
-    background-color: var(--c-hit-card-background);
-    border: 1px solid var(--c-hit-card-border);
+    background-color: var(--c-card-background);
+    border: 1px solid var(--c-card-border);
     border-radius: var(--border-radius-1);
   }
 `;

--- a/src/components/navGrid.js
+++ b/src/components/navGrid.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'gatsby';
+
+import Grid from './basics/grid';
+
+const NavCard = ({ slug, title, description }) => (
+  <div>
+    <Link to={slug}>
+      <h3>{title}</h3>
+    </Link>
+    <p>{description}</p>
+  </div>
+);
+
+NavCard.propTypes = {
+  slug: PropTypes.string,
+  title: PropTypes.string,
+  description: PropTypes.string,
+};
+
+const NavGrid = ({ links }) => (
+  <Grid gridGap="1em" minWidth="18em">
+    {links.map(({ slug, title, description }) => (
+      <NavCard key={slug} slug={slug} title={title} description={description} />
+    ))}
+  </Grid>
+);
+
+NavGrid.propTypes = {
+  links: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default NavGrid;

--- a/src/components/navGrid.js
+++ b/src/components/navGrid.js
@@ -12,6 +12,7 @@ const NavCardContainer = styled.div`
   background-color: var(--c-card-background);
   border: 1px solid var(--c-card-border);
   border-radius: var(--border-radius-1);
+  color: var(--c-card-text);
 
   h3 {
     line-height: 1.1;
@@ -19,6 +20,7 @@ const NavCardContainer = styled.div`
   }
 
   a {
+    color: var(--c-card-link);
     text-decoration: none;
 
     &: hover {

--- a/src/components/navGrid.js
+++ b/src/components/navGrid.js
@@ -1,16 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'gatsby';
+import styled from 'styled-components';
 
 import Grid from './basics/grid';
 
+const NavCardContainer = styled.div`
+  padding: var(--space-unit);
+  margin: 0;
+  box-shadow: var(--elevation-base);
+  background-color: #ffffff;
+
+  h3 {
+    line-height: 1.1;
+    margin: 0 0 1rem 0;
+  }
+
+  a {
+    text-decoration: none;
+
+    &: hover {
+      text-decoration: underline;
+    }
+  }
+
+  /* Knock out default margins to keep cards tidy. Cards always end in a
+  * paragraph.
+  */
+  p:last-child {
+    margin-bottom: 0;
+  }
+`;
+
 const NavCard = ({ slug, title, description }) => (
-  <div>
+  <NavCardContainer>
     <Link to={slug}>
       <h3>{title}</h3>
     </Link>
     <p>{description}</p>
-  </div>
+  </NavCardContainer>
 );
 
 NavCard.propTypes = {
@@ -20,7 +48,7 @@ NavCard.propTypes = {
 };
 
 const NavGrid = ({ links }) => (
-  <Grid gridGap="1em" minWidth="18em">
+  <Grid gridGap="1em" minWidth="12em">
     {links.map(({ slug, title, description }) => (
       <NavCard key={slug} slug={slug} title={title} description={description} />
     ))}

--- a/src/components/navGrid.js
+++ b/src/components/navGrid.js
@@ -9,7 +9,9 @@ const NavCardContainer = styled.div`
   padding: var(--space-unit);
   margin: 0;
   box-shadow: var(--elevation-base);
-  background-color: #ffffff;
+  background-color: var(--c-card-background);
+  border: 1px solid var(--c-card-border);
+  border-radius: var(--border-radius-1);
 
   h3 {
     line-height: 1.1;

--- a/src/components/pageLayer.js
+++ b/src/components/pageLayer.js
@@ -1,0 +1,53 @@
+/*
+ * PageLayer is a section-like component that provides a full-width background
+ * but contains content to the appropriate width.
+ */
+
+import styled, { css } from 'styled-components';
+
+const PageLayer = styled.section`
+  // Full-width in a contrained parent
+  // https://css-tricks.com/full-width-containers-limited-width-parents/
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: var(--space-lg) 0;
+  box-shadow: var(--elevation-lg);
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h4,
+  h5,
+  h6 {
+    margin-top: 0;
+  }
+
+  ${props =>
+    props.brand &&
+    css`
+      background-color: var(--c-brand-layer-background);
+      color: var(--c-brand-layer-text);
+      a {
+        color: var(--c-brand-layer-link);
+      }
+    `}
+
+  ${props =>
+    props.alternate &&
+    css`
+      background-color: var(--c-alternate-layer-background);
+      color: var(--c-alternate-layer-text);
+      a {
+        color: var(--c-alternate-layer-link);
+      }
+    `}
+`;
+
+export default PageLayer;

--- a/src/data/docSeries.yaml
+++ b/src/data/docSeries.yaml
@@ -1,0 +1,55 @@
+# Document series
+#
+# Each item is transformed into a category search page for that document
+# series in gatsby-node.js
+
+- key: DMTN
+  name: Data Management Technotes
+
+- key: DMTR
+  name: Data Management Test Reports
+  notice: >
+    Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.
+
+
+- key: ITTN
+  name: IT Technotes
+
+- key: LDM
+  name: LSST Data Management
+  notice: >
+    Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.
+
+
+- key: LPM
+  name: LSST Project Management
+  notice: >
+    Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.
+
+
+- key: LSE
+  name: LSST Systems Engineering
+  notice: >
+    Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.
+
+
+- key: OPSTN
+  name: Operations Technotes
+
+- key: PSTN
+  name: Project Science Team Technotes
+
+- key: RTN
+  name: Rubin Technotes
+
+- key: SMTN
+  name: Simulations Technotes
+
+- key: SITCOMTN
+  name: Systems Integration, Testing, and Commissioning Technotes
+
+- key: SQR
+  name: SQuaRE Technotes
+
+- key: TSTN
+  name: Telescope & Site Technotes

--- a/src/data/guideCollections.yaml
+++ b/src/data/guideCollections.yaml
@@ -1,0 +1,35 @@
+# User guide collections
+#
+# Each item is transformed into a page via the createPage function in
+# gatsby-node.js.
+#
+# The "tag" field selects collects of user guides with the corresponding tag
+# in the src/data/guides.yaml file.
+
+- title: Guides for scientists
+  slug: guides-for-scientists
+  tag: users/science
+  description: >
+    Learn how to use the Science Pipelines and Science Platform with these guides.
+
+
+- title: Guides for Data Management
+  slug: guides-for-dm
+  tag: users/dm
+  description: >
+    Documentation for Data Management's internal tooling and procedures.
+
+
+- title: Science Platform infrastructure documentation
+  slug: science-platform-infrastructure-guides
+  tag: system/science-platform
+  description: >
+    Developer and operational documentation for the Science Platform.
+
+
+- title: Roundtable infrastructure documentation
+  slug: roundtable-guides
+  tag: system/roundtable
+  description: >
+    Developer and operational documentation for the Roundtable platform, and services that run on Roundtable.
+

--- a/src/data/guideCollections.yaml
+++ b/src/data/guideCollections.yaml
@@ -24,7 +24,7 @@
   slug: science-platform-infrastructure-guides
   tag: system/science-platform
   description: >
-    Developer and operational documentation for the Science Platform.
+    Developer and operational documentation for the Science Platform and Data Facility.
 
 
 - title: Roundtable infrastructure documentation
@@ -32,4 +32,32 @@
   tag: system/roundtable
   description: >
     Developer and operational documentation for the Roundtable platform, and services that run on Roundtable.
+
+
+- title: Simulations documentation
+  slug: simulations-guides
+  tag: system/sims
+  description: >
+    Documentation for the LSST Simulations software packages.
+
+
+- title: Observatory documentation
+  slug: observatory-guides
+  tag: system/observatory
+  description: >
+    Rubin Observatory software components and operational documentation.
+
+
+- title: Science Pipelines documentation
+  slug: pipelines-guides
+  tag: system/pipelines
+  description: >
+    Documentation for the LSST Science Pipelines and related software.
+
+
+- title: Engineering Facility Database documentation
+  slug: efd-guides
+  tag: system/efd
+  description: >
+    Documentation for the Engineering Facility Database (EFD) software components.
 

--- a/src/data/guides.yaml
+++ b/src/data/guides.yaml
@@ -1,0 +1,31 @@
+- slug: developer
+  title: Data Management Developer Guide
+  github: lsst-dm/dm_dev_guide
+  tags:
+    - org/dm
+    - users/dm
+  description: >
+    This is an internal guide for Rubin Observatory / LSST DM staff. It’s also openly available so that others can understand how we’re building the LSST’s data management subsystem.
+
+
+- slug: nb
+  title: Rubin Science Platform Notebook Aspect User Guide
+  github: lsst-dm/nb_lsst_io
+  tags:
+    - org/dm
+    - users/science
+    - editorial/featured
+  description: >
+    The Notebook Aspect enables you to do your science at the LSST Data Facility, with the LSST Science Pipelines, a full suite of development tools, and your own Python code. The Notebook Aspect is powered by the JupyterLab project.
+
+
+- slug: pipelines
+  title: LSST Science Pipelines
+  github: lsst/pipelines_lsst_io
+  tags:
+    - org/dm
+    - users/science
+    - editorial/featured
+  description: >
+    The LSST Science Pipelines are designed to enable optical and near-infrared astronomy in the “big data” era. While they are being developed to process the data for the Rubin Observatory Legacy Survey of Space and Time (Rubin’s LSST), our command line and programming interfaces can be extended to address any optical or near-infrared dataset.
+

--- a/src/data/guides.yaml
+++ b/src/data/guides.yaml
@@ -1,3 +1,42 @@
+# User guides
+#
+# Tagging
+# org # organization that owns a project
+#   dm # Data Management
+#   ts # Telescope & Site
+#   se # Systems Engineering
+# users # user-oriented collections
+#   science # Science user oriented
+#   dm # Data Management internall tooling
+# system # system-themed collections
+#   pipelines # Science Pipelines
+#   roundtable # Roundtable services and libraries
+#   sims # Simulations software
+#   observatory # Observatory software
+#   efd # Engineering facility database
+#   science-platform # back-end infrastructure for the science platform and data facility
+
+- slug: astro-metadata-translator
+  title: astro_metadata_translator
+  github: lsst/astro_metadata_translator
+  tags:
+    - org/dm
+    - users/science
+    - system/pipelines
+  description: >
+    The astro_metadata_translator package provides generalized infrastructure for handling metadata extraction for astronomical instrumentation.
+
+
+- slug: cbp
+  title: cbp
+  github: lsst/cbp
+  tags:
+    - org/dm
+    - system/pipelines
+  description: >
+    The cbp package provides code for the LSST collimated beam projector (CBP).
+
+
 - slug: developer
   title: Data Management Developer Guide
   github: lsst-dm/dm_dev_guide
@@ -8,6 +47,139 @@
     This is an internal guide for Rubin Observatory / LSST DM staff. It’s also openly available so that others can understand how we’re building the LSST’s data management subsystem.
 
 
+- slug: display-firefly
+  title: lsst.display.firefly
+  github: lsst/display_firefly
+  tags:
+    - org/dm
+    - users/science
+    - system/pipelines
+  description: >
+    lsst.display.firefly is a backend for the lsst.afw.display interface, allowing the Firefly visualization framework to be used for displaying data objects from the LSST Science Pipelines.
+
+
+- slug: documenteer
+  title: Documenteer
+  github: lsst-sqre/documenteer
+  tags:
+    - org/dm
+    - users/dm
+  description: >
+    Sphinx extensions, configurations, and tooling for LSST Data Management documentation projects.
+
+
+- slug: efd-client
+  title: lsst-efd-client
+  github: lsst-sqre/lsst-efd-client
+  tags:
+    - org/dm
+    - users/dm
+    - system/efd
+  description: >
+    The LSST EFD Client helps you access the LSST Engineering Facility Database (EFD), which is backed by InfluxDB.
+
+
+- slug: felis
+  title: Felis
+  github: lsst-dm/felis
+  tags:
+    - org/dm
+    - system/pipelines
+  description: >
+    Felis is a way of describing database catalogs, scientific and otherwise, in a language and DBMS agnostic way. It’s built on concepts from JSON-LD/RDF and CSVW, but intended to provide a comprehensive way to describe tabular data, using annotations on tables, columns, and schemas, to document scientifically useful metadata as well as implementation-specific metadata for database management systems, file formats, and application data models.
+
+
+- slug: firefly
+  title: Firefly
+  github: Caltech-IPAC/firefly
+  tags:
+    - org/dm
+    - system/science-platform
+  description: >
+    JavaScript Firefly Tools API.
+
+
+- slug: firefly-client
+  title: firefly_client
+  github: https://github.com/Caltech-IPAC/firefly_client
+  tags:
+    - org/dm
+    - system/science-platform
+  description: >
+    Python API for Firefly, IPAC's Advanced Astronomy Web UI Framework.
+
+
+- slug: gafaelfawr
+  title: Gafaelfawr
+  github: lsst-sqre/gafaelfawr
+  tags:
+    - org/dm
+    - system/science-platform
+  description: >
+    Gafaelfawr is the authentication and authorization front-end for the Vera C. Rubin Observatory Science Platform.
+
+
+- slug: kafka-aggregator
+  title: kafka_aggregator
+  github: lsst-sqre/kafka-aggregator
+  tags:
+    - org/dm
+    - system/efd
+  description: >
+    A Kafka aggregator based on the Faust Python Stream Processing library.
+
+
+- slug: kafka-connect-manager
+  title: Kafka Connect Manager
+  github: lsst-sqre/kafka-connect-manager
+  tags:
+    - org/dm
+    - system/efd
+  description: >
+    Python client for managing the Confluent Kafka connect REST Interface on Kubernetes.
+
+
+- slug: kafkit
+  title: Kafkit
+  github: lsst-sqre/kafkit
+  tags:
+    - org/dm
+    - system/efd
+    - system/roundtable
+  description: >
+    Kafkit helps you write Kafka producers and consumers in Python with asyncio.
+
+
+- slug: lsst-texmf
+  title: lsst-texmf
+  github: lsst/lsst-texmf
+  tags:
+    - org/dm
+    - users/dm
+  description: >
+    The LSST lsst-texmf package contains LaTeX document classes, style files, and bibliographies that can be used to help you write LSST documentation in LaTeX to match the project style.
+
+
+- slug: ltd-conveyor
+  title: LTD Conveyor
+  github: lsst-sqre/ltd-conveyor
+  tags:
+    - org/dm
+    - users/dm
+  description: >
+    The command-line client for LSST the Docs, the documentation hosting platform.
+
+
+- slug: ltd-keeper
+  title: LTD Keeper
+  github: lsst-sqre/ltd-keeper
+  tags:
+    - org/dm
+    - system/roundtable
+  description: >
+    LTD Keeper is the backend database and application that runs LSST the Docs. You can interact with the Keeper through its RESTful HTTP API.
+
+
 - slug: nb
   title: Rubin Science Platform Notebook Aspect User Guide
   github: lsst-dm/nb_lsst_io
@@ -15,8 +187,60 @@
     - org/dm
     - users/science
     - editorial/featured
+    - system/science-platform
   description: >
     The Notebook Aspect enables you to do your science at the LSST Data Facility, with the LSST Science Pipelines, a full suite of development tools, and your own Python code. The Notebook Aspect is powered by the JupyterLab project.
+
+
+- slug: nbreport
+  title: nbreport
+  github: lsst-sqre/nbreport
+  tags:
+    - org/dm
+    - users/dm
+  description: >
+    nbreport is a client for creating and publishing LSST’s notebook-based reports. Notebook-based reports are generated from template repositories, computed, and published with LSST the Docs.
+
+
+- slug: neophile
+  title: Neophile
+  github: lsst-sqre/neophile
+  tags:
+    - org/dm
+    - users/dm
+    - system/roundtable
+  description: >
+    neophile is a dependency scanner. It looks through a repository for declared dependencies, attempts to determine if those dependencies are out of date, and generates a report.
+
+
+- slug: obs-controls
+  title: Rubin Observatory Controls Documentation
+  github: lsst-ts/observatory-controls-docs
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    The LSST Control Software contains the overall control aspects of the survey and the telescope including the computers, network, communication and software infrastructure.
+
+
+- slug: obs-ops
+  title: Rubin Observatory Operations Documentation
+  github: https://github.com/lsst-ts/observatory-controls-docs
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    This documentation focuses on the resources needed for observers, commissioning personnel, and support staff to facilitate night-time operations.
+
+
+- slug: phalanx
+  title: Phalanx
+  github: lsst-sqre/lsp-deploy
+  tags:
+    - org/dm
+    - system/science-platform
+  description: >
+    This documentation contains operational notes of interest to administrators of the Science Platform but not of interest to users.
 
 
 - slug: pipelines
@@ -25,7 +249,359 @@
   tags:
     - org/dm
     - users/science
+    - system/pipelines
     - editorial/featured
   description: >
     The LSST Science Pipelines are designed to enable optical and near-infrared astronomy in the “big data” era. While they are being developed to process the data for the Rubin Observatory Legacy Survey of Space and Time (Rubin’s LSST), our command line and programming interfaces can be extended to address any optical or near-infrared dataset.
+
+
+- slug: qserv
+  title: Qserv
+  github: lsst/qserv
+  tags:
+    - org/dm
+    - system/science-platform
+  description: >
+    LSST Query Services (Qserv) provides access to the LSST Database Catalogs.
+
+
+- slug: qserv-operator
+  title: Qserv-operator
+  github: lsst/qserv-operator
+  tags:
+    - org/dm
+    - system/science-platform
+  description: >
+    A qserv operator for Kubernetes based on operator-framework.
+
+
+- slug: roundtable
+  title: Roundtable
+  github: lsst-sqre/roundtable
+  tags:
+    - org/dm
+    - system/roundtable
+  description: >
+    Roundtable is a Kubernetes cluster for microservices, managed by the SQuaRE team.
+
+
+- slug: safir
+  title: Safir
+  github: lsst-sqre/safir
+  tags:
+    - org/dm
+    - system/roundtable
+  description: Safir is a Python package that lets you develop Roundtable bots, based on the aiohttp.web asyncio web framework.
+
+- slug: services
+  title: Rubin Observatory services directory
+  github: lsst-sqre/services
+  tags:
+    - org/dm
+    - system/roundtable
+  description: >
+    A directory of services operated by the SQuaRE team.
+
+
+- slug: sims-maf
+  title: Simulations Metric Analysis Framework (MAF)
+  github: lsst/sims_maf
+  tags:
+    - org/se
+    - system/sims
+  description: >
+    The Metrics Analysis Framework (MAF) is a software package intended to make it easier to write code to analyze telescope pointing histories; in particular, the primary use case is to analyze simulated surveys generated by the LSST Operations Simulator (OpSim).
+
+
+- slug: sims-movingobjects
+  title: sims_movingObjects
+  github: lsst/sims_movingObjects
+  tags:
+    - org/se
+    - system/sims
+  description: >
+    The sims_movingObjects package generates observations of moving objects as ‘seen’ in a simulated pointing history.
+
+
+- slug: sims-survey-fields
+  title: lsst.sims.survey.fields
+  github: lsst/sims_survey_fields
+  tags:
+    - org/se
+    - system/sims
+  description: >
+    This package contains the sky field information that is used by the Operations Simulator.
+
+
+- slug: templatekit
+  title: Templatekit
+  github: lsst-sqre/templatekit
+  tags:
+    - org/dm
+    - users/dm
+    - system/roundtable
+  description: >
+    Templatekit is a command-line app and Python library for using and maintaining a centralized repository of project and file templates that are built with Cookiecutter and Jinja.
+
+
+- slug: ts-atdome
+  title: lsst.ts.ATDome
+  github: lsst-ts/ts_ATDome
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    Controller for the LSST auxiliary telescope dome.
+
+
+- slug: ts-atdometrajectory
+  title: lsst.ts.ATDomeTrajectory
+  github: lsst-ts/ts_ATDomeTrajectory
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    ATDomeTrajectory CSC commands the dome to follow the telescope.
+
+
+- slug: ts-athexapod
+  title: lsst.ts.ATHexapod
+  github: lsst-ts/ts_ATHexapod
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    The ATHexapod is a python package that implements the CSC that controls a PI H-824 hexapod that holds the secondary mirror on the Auxiliary Telescope. The hexapod allows precise positioning of the mirror, which is key to performing optical collimation of the telescope as well as focus adjustments.
+
+
+- slug: ts-atmcssimulator
+  title: lsst.ts.ATMCSSimulator
+  github: lsst-ts/ts_ATMCSSimulator
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    A simulator for the auxiliary telescope motor control system (ATMCS CSC).
+
+
+- slug: ts-atpneumaticssimulator
+  title: lsst.ts.ATPneumaticsSimulator
+  github: lsst-ts/ts_ATPneumaticsSimulator
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    A simulator for the auxiliary telescope pneumatics control system (ATPneumatics CSC).
+
+
+- slug: ts-authorization
+  title: lsst.ts.authorize
+  github: lsst-ts/ts_authorize
+  tags:
+    - org/ts
+    - system/efd
+  description: >
+    Handle authorization requests for SAL users.
+
+
+- slug: ts-dome
+  title: lsst.ts.dome
+  github: lsst-ts/ts_dome
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    Controller for the Simonyi Survey Telescope dome at Vera C. Rubin Observatory.
+
+
+- slug: ts-externalscripts
+  title: ts_externalscripts
+  github: lsst-ts/ts_externalscripts
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    Non-supported SAL scripts for operating the LSST via the lsst.ts.scriptqueue.ScriptQueue.
+
+
+- slug: ts-fiberspectrograph
+  title: lsst.ts.FiberSpectrograph
+  github: lsst-ts/ts_FiberSpectrograph
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    Commandable SAL Component (CSC) to control the fiber spectrographs that are used to determine the wavelengths of the LSST calibration lamps and lasers.
+
+
+- slug: ts-hexapod
+  title: lsst.ts.hexapod
+  github: lsst-ts/ts_hexapod
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    Python Commandable SAL Component (CSC) for the camera and M2 hexapods on the Simonyi Survey Telescope.
+
+
+- slug: ts-hexrotcomm
+  title: lsst.ts.hexrotcomm
+  github: lsst-ts/ts_hexrotcomm
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    - Python code to communicate with the main telescope camera rotator and hexapod low level controllers (code running in PXI computers).
+
+
+- slug: ts-mtaos
+  title: MTAOS
+  github: lsst-ts/ts_MTAOS
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    The main telescope active optical system (MTAOS) is responsible for making the closed-loop optical system. It calculates the wavefront error based on defocal images, estimates the optical state, and sends the correction of bending modes and rigid body positions to mirrors and hexapods.
+
+
+- slug: ts-mtdometrajectory
+  title: lsst.ts.MTDomeTrajectory
+  github: lsst-ts/ts_MTDomeTrajectory
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    ts_MTDomeTrajectory contains the MTDomeTrajectory CSC and support code.
+
+
+- slug: ts-mtmount
+  title: lsst.ts.MTMount
+  github: lsst-ts/ts_MTMount
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    A CSC that controls the Simonyi Survey Telescope main axes and related components.
+
+
+- slug: ts-observatory-control
+  title: lsst.ts.observatory.control
+  github: lsst-ts/ts_observatory_control
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    Observatory control software.
+
+
+- slug: ts-rotator
+  title: lsst.ts.rotator
+  github: lsst-ts/ts_rotator
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    Python Commandable SAL Component (CSC) for the LSST main telescope rotator.
+
+
+- slug: ts-sal
+  title: lsst.ts.sal
+  github: lsst-ts/ts_sal
+  tags:
+    - org/ts
+    - system/observatory
+    - system/efd
+  description: >
+    Service Abstraction Layer (SAL) is LSST’s communications middleware. Built on top of Object Management Group’s Data Distribution Service (OMG DDS) standard.
+
+
+- slug: ts-salkafka
+  title: lsst.ts.salkafka
+  github: lsst-ts/ts_salkafka
+  tags:
+    - org/ts
+    - system/observatory
+    - system/efd
+  description: >
+    Forward DDS samples from one or more SAL components to a Kafka broker, to populate databases.
+
+
+- slug: ts-salobj
+  title: lsst.ts.salobj
+  github: lsst-ts/ts_salobj
+  tags:
+    - org/ts
+    - system/observatory
+    - system/efd
+  description: >
+    Object-oriented Python interface to Service Abstraction Layer (SAL) components that uses asyncio for asynchronous communication.
+
+
+- slug: ts-scriptqueue
+  title: lsst.ts.scriptqueue
+  github: lsst-ts/ts_scriptqueue
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    lsst.ts.scriptqueue
+
+
+- slug: ts-simactuators
+  title: lsst.ts.simactuators
+  github: lsst-ts/ts_simactuators
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    Python actuator simulators intended for the simulations in Commandable SAL Components (CSCs).
+
+
+- slug: ts-standardscripts
+  title: lsst.ts.standardscripts
+  github: lsst-ts/ts_standardscripts
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    SAL scripts for operating the Vera Rubin Observatory.
+
+
+- slug: ts-tma
+  title: Telescope Mount Assembly Documentation
+  github: lsst-ts/
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    Telescope Mount Assembly Documentation provided by the vendor.
+
+
+- slug: ts-watcher
+  title: lsst.ts.watcher
+  github: lsst-ts/ts_watcher
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    A CSC which monitors other SAL components and uses the data to generate alarms for display by LOVE.
+
+
+- slug: ts-xml
+  title: ts_xml
+  github: lsst-ts/ts_xml
+  tags:
+    - org/ts
+    - system/observatory
+  description: >
+    The ts_xml package defines the data objects for all Commandable SAL Components (CSC).
+
+
+- slug: tssw-developer
+  title: TSSW Developer Guide
+  github: lsst-ts/tssw_developer_guide
+  tags:
+    - org/ts
+  description: >
+    The TSSW developer guide as ported from Confluence.
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 
 import Layout from '../components/layout';
 import SEO from '../components/seo';
+import PageLayer from '../components/pageLayer';
+import PageContentContainer from '../components/pageContentContainer';
 
 const ContentTable = styled.table`
   width: 100%;
@@ -69,180 +71,189 @@ const AboutPage = () => (
 
     <h1>About the technical documentation portal</h1>
 
-    <h2 id="purpose">Purpose</h2>
+    <PageLayer>
+      <PageContentContainer>
+        <h2 id="purpose">Purpose</h2>
 
-    <p>
-      The goal of this documentation portal is to help you access and discover
-      the Rubin Observatory’s public technical documentation. This portal is
-      available to everyone: the observatory team, the astronomy community, and
-      the general public.
-    </p>
+        <p>
+          The goal of this documentation portal is to help you access and
+          discover the Rubin Observatory’s public technical documentation. This
+          portal is available to everyone: the observatory team, the astronomy
+          community, and the general public.
+        </p>
 
-    <p>
-      Although there may be some public technical documentation that is not yet
-      available through this search portal, we index all our technote document
-      series, and are adding new sources all the time. See{' '}
-      <a href="#content-coverage">the content coverage table</a>, below for
-      details.
-    </p>
+        <p>
+          Although there may be some public technical documentation that is not
+          yet available through this search portal, we index all our technote
+          document series, and are adding new sources all the time. See{' '}
+          <a href="#content-coverage">the content coverage table</a>, below for
+          details.
+        </p>
 
-    <p>
-      <em>
-        Documentation that isn’t public is beyond the scope of this portal.
-      </em>{' '}
-      Observatory team members should log into individual platforms to find
-      non-public information, such as{' '}
-      <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">
-        DocuShare
-      </a>
-      , <a href="https://jira.lsstcorp.org/secure/Dashboard.jspa">Jira</a>,{' '}
-      <a href="https://confluence.lsstcorp.org">Confluence</a>, or the{' '}
-      <a href="https://project.lsst.org/">Project homepage</a>.
-    </p>
+        <p>
+          <em>
+            Documentation that isn’t public is beyond the scope of this portal.
+          </em>{' '}
+          Observatory team members should log into individual platforms to find
+          non-public information, such as{' '}
+          <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">
+            DocuShare
+          </a>
+          , <a href="https://jira.lsstcorp.org/secure/Dashboard.jspa">Jira</a>,{' '}
+          <a href="https://confluence.lsstcorp.org">Confluence</a>, or the{' '}
+          <a href="https://project.lsst.org/">Project homepage</a>.
+        </p>
+      </PageContentContainer>
+    </PageLayer>
 
-    <h2 id="content-coverage">Content coverage</h2>
+    <PageLayer>
+      <PageContentContainer>
+        <h2 id="content-coverage">Content coverage</h2>
 
-    <p>
-      Content types are added systematically as we develop our content indexer,{' '}
-      <a href="https://github.com/lsst-sqre/ook">Ook</a>. The following table
-      summarizes the types of content that are currently available through the
-      portal, along with content types that we anticipate adding in the future.
-    </p>
+        <p>
+          Content types are added systematically as we develop our content
+          indexer, <a href="https://github.com/lsst-sqre/ook">Ook</a>. The
+          following table summarizes the types of content that are currently
+          available through the portal, along with content types that we
+          anticipate adding in the future.
+        </p>
 
-    <ContentTable>
-      <caption>Status of content availability in this portal.</caption>
-      <thead>
-        <tr>
-          <th className="col-category"></th>
-          <th className="col-type" scope="col">
-            Content type
-          </th>
-          <th className="col-check" scope="col">
-            Search{' '}
-            <sup>
-              <a href="#content-types-fn1">[1]</a>
-            </sup>
-          </th>
-          <th className="col-check" scope="col">
-            Browse{' '}
-            <sup>
-              <a href="#content-types-fn2">[2]</a>
-            </sup>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th className="category" rowSpan="11" scope="row">
-            Documents
-          </th>
-          <td>Technical notes on lsst.io &mdash; LaTeX</td>
-          <td>Yes</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <td>Technical notes on lsst.io &mdash; rst format</td>
-          <td>Yes</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <td>DMTR &mdash; lsst.io</td>
-          <td>Yes</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <td>DMTR &mdash; DocuShare (public)</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>LDM &mdash; lsst.io</td>
-          <td>Yes</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <td>LDM &mdash; DocuShare (public)</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>LPM &mdash; lsst.io</td>
-          <td>Yes</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <td>LPM &mdash; DocuShare (public)</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>LSE &mdash; lsst.io</td>
-          <td>Yes</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <td>LSE &mdash; DocuShare (public)</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>Zenodo &mdash; lsst-dm community</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th className="category" scope="row">
-            Guides
-          </th>
-          <td>Sphinx-based guides &mdash; lsst.io</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th className="category" scope="row" rowSpan="2">
-            Discussions
-          </th>
-          <td>Community forum (public)</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>DM RFC (public)</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th className="category" scope="row">
-            Software
-          </th>
-          <td>GitHub repositories</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th className="category" scope="row">
-            Misc.
-          </th>
-          <td>Glossary terms</td>
-          <td></td>
-          <td></td>
-        </tr>
-      </tbody>
-      <tfoot>
-        <tr>
-          <td colSpan="4" id="content-types-fn1">
-            <sup>[1]</sup> “Search” means the full text content is searchable
-            from the Advanced search page.
-          </td>
-        </tr>
-        <tr>
-          <td colSpan="4" id="content-types-fn2">
-            <sup>[2]</sup> “Browse” means the entity is linked from a page on
-            this portal.
-          </td>
-        </tr>
-      </tfoot>
-    </ContentTable>
+        <ContentTable>
+          <caption>Status of content availability in this portal.</caption>
+          <thead>
+            <tr>
+              <th className="col-category"></th>
+              <th className="col-type" scope="col">
+                Content type
+              </th>
+              <th className="col-check" scope="col">
+                Search{' '}
+                <sup>
+                  <a href="#content-types-fn1">[1]</a>
+                </sup>
+              </th>
+              <th className="col-check" scope="col">
+                Browse{' '}
+                <sup>
+                  <a href="#content-types-fn2">[2]</a>
+                </sup>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th className="category" rowSpan="11" scope="row">
+                Documents
+              </th>
+              <td>Technical notes on lsst.io &mdash; LaTeX</td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>Technical notes on lsst.io &mdash; rst format</td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>DMTR &mdash; lsst.io</td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>DMTR &mdash; DocuShare (public)</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>LDM &mdash; lsst.io</td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>LDM &mdash; DocuShare (public)</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>LPM &mdash; lsst.io</td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>LPM &mdash; DocuShare (public)</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>LSE &mdash; lsst.io</td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>LSE &mdash; DocuShare (public)</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Zenodo &mdash; lsst-dm community</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th className="category" scope="row">
+                Guides
+              </th>
+              <td>Sphinx-based guides &mdash; lsst.io</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th className="category" scope="row" rowSpan="2">
+                Discussions
+              </th>
+              <td>Community forum (public)</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>DM RFC (public)</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th className="category" scope="row">
+                Software
+              </th>
+              <td>GitHub repositories</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th className="category" scope="row">
+                Misc.
+              </th>
+              <td>Glossary terms</td>
+              <td></td>
+              <td></td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colSpan="4" id="content-types-fn1">
+                <sup>[1]</sup> “Search” means the full text content is
+                searchable from the Advanced search page.
+              </td>
+            </tr>
+            <tr>
+              <td colSpan="4" id="content-types-fn2">
+                <sup>[2]</sup> “Browse” means the entity is linked from a page
+                on this portal.
+              </td>
+            </tr>
+          </tfoot>
+        </ContentTable>
+      </PageContentContainer>
+    </PageLayer>
   </Layout>
 );
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -205,7 +205,7 @@ const AboutPage = () => (
               </th>
               <td>Sphinx-based guides &mdash; lsst.io</td>
               <td></td>
-              <td></td>
+              <td>Yes</td>
             </tr>
             <tr>
               <th className="category" scope="row" rowSpan="2">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,200 +1,113 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { graphql, StaticQuery, Link } from 'gatsby';
-import BackgroundImage from 'gatsby-background-image';
-import styled from 'styled-components';
+import { graphql, Link } from 'gatsby';
 
 import Layout from '../components/layout';
 import SEO from '../components/seo';
+import {
+  StyledBackgroundSection,
+  StyledSearchContainer,
+} from '../components/index/backgroundSection';
 import HeroSearchForm from '../components/heroSearchForm';
-import PageContentContainer from '../components/pageContentContainer';
 import FeaturedGuides from '../components/featuredGuides';
+import NavGrid from '../components/navGrid';
 
-const BackgroundSection = ({ className, children }) => (
-  <StaticQuery
-    query={graphql`
-      query {
-        desktop: file(relativePath: { eq: "lsst-stills-0014.jpg" }) {
-          childImageSharp {
-            fluid(quality: 90, maxWidth: 1920) {
-              ...GatsbyImageSharpFluid_withWebp
-            }
-          }
+export const query = graphql`
+  query {
+    allDocSeriesYaml(sort: { fields: key, order: ASC }) {
+      edges {
+        node {
+          key
+          name
         }
       }
-    `}
-    render={data => {
-      const imageData = data.desktop.childImageSharp.fluid;
+    }
+    allGuideCollectionsYaml(sort: { fields: title, order: ASC }) {
+      edges {
+        node {
+          slug
+          title
+          description
+        }
+      }
+    }
+  }
+`;
 
-      return (
-        <BackgroundImage
-          Tag="section"
-          className={className}
-          fluid={imageData}
-          backgroundColor="var(--c-reversed-background)"
-        >
-          {children}
-        </BackgroundImage>
-      );
-    }}
-  />
-);
+const IndexPage = ({ data }) => {
+  const { allDocSeriesYaml, allGuideCollectionsYaml } = data;
 
-BackgroundSection.propTypes = {
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string,
+  // Adapt the shape of GraphQL to the NavGrid props
+  const docSeriesData = allDocSeriesYaml.edges.map(({ node }) => ({
+    slug: node.key.toLowerCase(),
+    title: node.key,
+    description: node.name,
+  }));
+
+  const guideCollectionsData = allGuideCollectionsYaml.edges.map(
+    ({ node }) => ({
+      slug: node.slug,
+      title: node.title,
+      description: node.description,
+    })
+  );
+
+  return (
+    <Layout>
+      <SEO title="Home" />
+
+      <StyledBackgroundSection>
+        <StyledSearchContainer>
+          <div className="wrapper">
+            <div className="principal">
+              <h1>Find Rubin Observatory technical docs and software.</h1>
+
+              <HeroSearchForm role="search" />
+            </div>
+          </div>
+        </StyledSearchContainer>
+      </StyledBackgroundSection>
+
+      <section>
+        <h2>Featured guides</h2>
+        <FeaturedGuides />
+      </section>
+
+      <section>
+        <h2>Documents</h2>
+
+        <p>
+          <Link to="/search/?hierarchicalMenu[contentCategories.lvl0]=Documents">
+            Search in Rubin Observatory technical documents,
+          </Link>{' '}
+          or browse by series:
+        </p>
+
+        <NavGrid links={docSeriesData} />
+
+        <p>
+          <small>
+            <sup>*</sup> Documents held only in{' '}
+            <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">
+              DocuShare
+            </a>{' '}
+            are not yet part of the search results.{' '}
+            <Link to="/about/">Learn more.</Link>
+          </small>
+        </p>
+      </section>
+
+      <section>
+        <h2>Guides</h2>
+
+        <NavGrid links={guideCollectionsData} />
+      </section>
+    </Layout>
+  );
 };
 
-const StyledBackgroundSection = styled(BackgroundSection)`
-  // Full-width in a contrained parent
-  // https://css-tricks.com/full-width-containers-limited-width-parents/
-  width: 100vw;
-  position: relative;
-  left: 50%;
-  right: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
-
-  // Background image
-  background-position: bottom center;
-  background-size: cover;
-
-  // Effectively a "reversed" block; doesn't change based on theme
-  color: var(--c-reversed-text);
-`;
-
-/*
- * Container for content within the BackgroundSection.
- *
- * Using flexbox to center the hero content.
- */
-const StyledSearchContainer = styled(PageContentContainer)`
-  .wrapper {
-    display: flex;
-    flex-direction: column;
-    height: 70vh; // Give a peak of content down the page
-  }
-
-  .principal {
-    margin-top: auto;
-    margin-bottom: auto;
-  }
-`;
-
-const IndexPage = () => (
-  <Layout>
-    <SEO title="Home" />
-
-    <StyledBackgroundSection>
-      <StyledSearchContainer>
-        <div className="wrapper">
-          <div className="principal">
-            <h1>Find Rubin Observatory technical docs and software.</h1>
-
-            <HeroSearchForm role="search" />
-          </div>
-        </div>
-      </StyledSearchContainer>
-    </StyledBackgroundSection>
-    <section>
-      <h2>Featured guides</h2>
-      <FeaturedGuides />
-    </section>
-    <section>
-      <h2>Documents</h2>
-
-      <p>
-        <Link to="/search/?hierarchicalMenu[contentCategories.lvl0]=Documents">
-          Search in Rubin Observatory technical documents,
-        </Link>{' '}
-        or browse by series:
-      </p>
-
-      <ul>
-        <li>
-          <Link to="/dmtn/">
-            <strong>DMTN</strong> &mdash; Data Management Technotes
-          </Link>
-        </li>
-        <li>
-          <Link to="/dmtr/">
-            <strong>DMTR</strong> &mdash; Data Management Test Reports
-          </Link>
-          <sup>*</sup>
-        </li>
-        <li>
-          <Link to="/ittn/">
-            <strong>ITTN</strong> &mdash; IT Technotes
-          </Link>
-        </li>
-        <li>
-          <Link to="/ldm/">
-            <strong>LDM</strong> &mdash; LSST Data Management
-          </Link>
-          <sup>*</sup>
-        </li>
-        <li>
-          <Link to="/lpm/">
-            <strong>LPM</strong> &mdash; LSST Project Management
-          </Link>
-          <sup>*</sup>
-        </li>
-        <li>
-          <Link to="/lse/">
-            <strong>LSE</strong> &mdash; LSST Systems Engineering
-          </Link>
-          <sup>*</sup>
-        </li>
-        <li>
-          <Link to="/opstn/">
-            <strong>OPSTN</strong> &mdash; Operations Technotes
-          </Link>
-        </li>
-        <li>
-          <Link to="/pstn/">
-            <strong>PSTN</strong> &mdash; Project Science Team Technotes
-          </Link>
-        </li>
-        <li>
-          <Link to="/rtn/">
-            <strong>RTN</strong> &mdash; Rubin Technotes
-          </Link>
-        </li>
-        <li>
-          <Link to="/smtn/">
-            <strong>SMTN</strong> &mdash; Simulations Technotes
-          </Link>
-        </li>
-        <li>
-          <Link to="/sitcomtn/">
-            <strong>SITCOMTN</strong> &mdash; Systems Integration, Testing, and
-            Commissioning Technotes
-          </Link>
-        </li>
-        <li>
-          <Link to="/sqr/">
-            <strong>SQR</strong> &mdash; SQuaRE Technotes
-          </Link>
-        </li>
-        <li>
-          <Link to="/tstn/">
-            <strong>TSTN</strong> &mdash; Telescope &amp; Site Technotes
-          </Link>
-        </li>
-      </ul>
-
-      <p>
-        <small>
-          <sup>*</sup> Documents held only in{' '}
-          <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">
-            DocuShare
-          </a>{' '}
-          are not yet part of the search results.{' '}
-          <Link to="/about/">Learn more.</Link>
-        </small>
-      </p>
-    </section>
-  </Layout>
-);
+IndexPage.propTypes = {
+  data: PropTypes.object.isRequired,
+};
 
 export default IndexPage;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types';
 import { graphql, Link } from 'gatsby';
 
 import Layout from '../components/layout';
+import PageContentContainer from '../components/pageContentContainer';
 import SEO from '../components/seo';
 import {
   StyledBackgroundSection,
   StyledSearchContainer,
 } from '../components/index/backgroundSection';
+import PageLayer from '../components/pageLayer';
 import HeroSearchForm from '../components/heroSearchForm';
 import FeaturedGuides from '../components/featuredGuides';
 import NavGrid from '../components/navGrid';
@@ -68,40 +70,46 @@ const IndexPage = ({ data }) => {
         </StyledSearchContainer>
       </StyledBackgroundSection>
 
-      <section>
-        <h2>Featured guides</h2>
-        <FeaturedGuides />
-      </section>
+      <PageLayer brand>
+        <PageContentContainer>
+          <h2>Featured guides</h2>
+          <FeaturedGuides />
+        </PageContentContainer>
+      </PageLayer>
 
-      <section>
-        <h2>Documents</h2>
+      <PageLayer>
+        <PageContentContainer>
+          <h2>Documents</h2>
 
-        <p>
-          <Link to="/search/?hierarchicalMenu[contentCategories.lvl0]=Documents">
-            Search in Rubin Observatory technical documents,
-          </Link>{' '}
-          or browse by series:
-        </p>
+          <p>
+            <Link to="/search/?hierarchicalMenu[contentCategories.lvl0]=Documents">
+              Search in Rubin Observatory technical documents,
+            </Link>{' '}
+            or browse by series:
+          </p>
 
-        <NavGrid links={docSeriesData} />
+          <NavGrid links={docSeriesData} />
 
-        <p>
-          <small>
-            <sup>*</sup> Documents held only in{' '}
-            <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">
-              DocuShare
-            </a>{' '}
-            are not yet part of the search results.{' '}
-            <Link to="/about/">Learn more.</Link>
-          </small>
-        </p>
-      </section>
+          <p>
+            <small>
+              <sup>*</sup> Documents held only in{' '}
+              <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">
+                DocuShare
+              </a>{' '}
+              are not yet part of the search results.{' '}
+              <Link to="/about/">Learn more.</Link>
+            </small>
+          </p>
+        </PageContentContainer>
+      </PageLayer>
 
-      <section>
-        <h2>Guides</h2>
+      <PageLayer alternate>
+        <PageContentContainer>
+          <h2>Guides</h2>
 
-        <NavGrid links={guideCollectionsData} />
-      </section>
+          <NavGrid links={guideCollectionsData} />
+        </PageContentContainer>
+      </PageLayer>
     </Layout>
   );
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,6 +8,7 @@ import Layout from '../components/layout';
 import SEO from '../components/seo';
 import HeroSearchForm from '../components/heroSearchForm';
 import PageContentContainer from '../components/pageContentContainer';
+import FeaturedGuides from '../components/featuredGuides';
 
 const BackgroundSection = ({ className, children }) => (
   <StaticQuery
@@ -95,6 +96,10 @@ const IndexPage = () => (
         </div>
       </StyledSearchContainer>
     </StyledBackgroundSection>
+    <section>
+      <h2>Featured guides</h2>
+      <FeaturedGuides />
+    </section>
     <section>
       <h2>Documents</h2>
 

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -94,8 +94,11 @@ export default function DocSeriesTemplate({
       <SEO title={docSeries.name} description={docSeries.description} />
       <h1>{docSeries.name}</h1>
 
-      {/* eslint-disable-next-line react/no-danger */}
-      {docSeries.notice && <p dangerouslySetInnerHTML={docSeries.notice} />}
+      {/* eslint-disable react/no-danger */}
+      {docSeries.notice && (
+        <p dangerouslySetInnerHTML={{ __html: docSeries.notice }} />
+      )}
+      {/* eslint-enable react/no-danger */}
 
       <InstantSearch
         searchClient={searchClient}

--- a/src/templates/guideCollection.js
+++ b/src/templates/guideCollection.js
@@ -9,6 +9,8 @@ import { graphql } from 'gatsby';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
 import GuideGrid from '../components/guideGrid';
+import PageLayer from '../components/pageLayer';
+import PageContentContainer from '../components/pageContentContainer';
 
 export const query = graphql`
   query UserGuideCollection($tag: String!) {
@@ -38,7 +40,11 @@ const GuideCollectionTemplate = ({ pageContext, data }) => {
 
       <p>{description}</p>
 
-      <GuideGrid guides={data.allGuidesYaml.edges} />
+      <PageLayer>
+        <PageContentContainer>
+          <GuideGrid guides={data.allGuidesYaml.edges} />
+        </PageContentContainer>
+      </PageLayer>
     </Layout>
   );
 };

--- a/src/templates/guideCollection.js
+++ b/src/templates/guideCollection.js
@@ -1,0 +1,51 @@
+/**
+ * Template for a page that collects user guides matching a specific tag.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { graphql } from 'gatsby';
+
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+import GuideGrid from '../components/guideGrid';
+
+export const query = graphql`
+  query UserGuideCollection($tag: String!) {
+    allGuidesYaml(
+      filter: { tags: { eq: $tag } }
+      sort: { fields: title, order: ASC }
+    ) {
+      edges {
+        node {
+          slug
+          github
+          description
+          title
+        }
+      }
+    }
+  }
+`;
+
+const GuideCollectionTemplate = ({ pageContext, data }) => {
+  const { title, description } = pageContext;
+
+  return (
+    <Layout>
+      <SEO title={title} description={description} />
+      <h1>{title}</h1>
+
+      <p>{description}</p>
+
+      <GuideGrid guides={data.allGuidesYaml.edges} />
+    </Layout>
+  );
+};
+
+GuideCollectionTemplate.propTypes = {
+  pageContext: PropTypes.object.isRequired,
+  data: PropTypes.object.isRequired,
+};
+
+export default GuideCollectionTemplate;


### PR DESCRIPTION
We want to include guides (multi-page documentation projects) in the documentation hub, but we don't have support in Ook for this type of documentation yet. An interim solution, we can statically list user guide projects and provide links. Further, we can provide browseable collections of user guides based on a technology system or a user community.

This PR implements that interim solution. On the data side, user guides are listed in `/src/data/guides.yaml`. A single guide's object looks like this:

```yaml
- slug: kafkit
  title: Kafkit
  github: lsst-sqre/kafkit
  tags:
    - org/dm
    - system/efd
    - system/roundtable
  description: >
    Kafkit helps you write Kafka producers and consumers in Python with asyncio.
```

Collections of guides are listed in `/src/data/guideCollections.yaml`. Collections are based on tags:

```yaml
- title: Roundtable infrastructure documentation
  slug: roundtable-guides
  tag: system/roundtable
  description: >
    Developer and operational documentation for the Roundtable platform, and services that run on Roundtable.
```

In `gatsby-node.js` we generate pages for each guide collection.

On the homepages, guides are presented in a "Featured guides" section and well as collections of guides in a "Guides" section:

![Screenshot_2020-08-04 Home](https://user-images.githubusercontent.com/349384/89329781-466be480-d65d-11ea-8f6a-7a1688e3cbec.png)

Guide collection pages present individual guides in a grid:

![Screenshot_2020-08-04 Guides for Data Management](https://user-images.githubusercontent.com/349384/89329877-70bda200-d65d-11ea-9b0b-b264d65a0315.png)
