### PR TITLE
DM-26137: Explain for what content is available from the site

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
-    title: `Vera Rubin Observatory Documentation`,
-    description: `Find Vera Rubin Observatory documentation and open source projects.`,
+    title: `Vera Rubin Observatory Technical Documentation`,
+    description: `Find Vera Rubin Observatory technical documentation and software.`,
     author: `@VRubinObs`,
     siteUrl: `https://www.lsst.io`,
   },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -17,7 +17,7 @@ exports.createPages = ({ actions }) => {
       name: 'Data Management Test Reports',
       notice: {
         __html:
-          'These results do not contain documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a>.',
+          'Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.',
       },
     },
     {
@@ -33,7 +33,7 @@ exports.createPages = ({ actions }) => {
       name: 'LSST Data Management',
       notice: {
         __html:
-          'These results do not contain documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a>.',
+          'Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.',
       },
     },
     {
@@ -41,7 +41,7 @@ exports.createPages = ({ actions }) => {
       name: 'LSST Project Management',
       notice: {
         __html:
-          'These results do not contain documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a>.',
+          'Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.',
       },
     },
     {
@@ -49,7 +49,7 @@ exports.createPages = ({ actions }) => {
       name: 'LSST Systems Engineering',
       notice: {
         __html:
-          'These results do not contain documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a>.',
+          'Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.',
       },
     },
     {

--- a/src/components/globalStyles.js
+++ b/src/components/globalStyles.js
@@ -149,6 +149,8 @@ const GlobalStyle = createGlobalStyle`
     --c-hit-card-background: #FFFFFF;
     --c-hit-card-border: none;
     --c-algolia-text: #182359;
+    --c-table-border: var(--c-primary);
+    --c-table-row-highlight: var(--c-neutral-100);
 
     /*
      * Elevations
@@ -231,6 +233,8 @@ const GlobalStyle = createGlobalStyle`
     --c-icon-primary: var(--c-primary);
     --c-icon-secondary: var(--c-neutral-100);
     --c-algolia-text: var(--c-text);
+    --c-table-row-highlight: var(--c-cyan-900);
+    --c-table-border: var(--c-text);
   }
 
   a {

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -50,6 +50,9 @@ const Header = () => (
                 <li>
                   <Link to="/search/">Advanced search</Link>
                 </li>
+                <li>
+                  <Link to="/about/">About</Link>
+                </li>
                 {/* Add links for more categories/pages */}
               </NavList>
             </Cluster>

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,0 +1,249 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+
+const ContentTable = styled.table`
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+
+  th,
+  td {
+    text-align: left;
+    vertical-align: baseline;
+    padding: var(--space-xxxs);
+  }
+
+  .col-category {
+    width: 20%;
+  }
+
+  .col-type {
+    width: 60%;
+  }
+
+  .col-part {
+    width: 40%;
+  }
+
+  .col-part2 {
+    width: 20%;
+  }
+
+  .col-check {
+    width: 10%;
+  }
+
+  tbody tr:nth-child(even) {
+    background-color: var(--c-table-row-highlight);
+  }
+
+  .category {
+    background-color: var(--c-background);
+  }
+
+  tbody,
+  tfoot,
+  thead {
+    border-top: 1px solid var(--c-table-border);
+    border-bottom: 1px solid var(--c-table-border);
+  }
+
+  tfoot {
+    font-size: 0.8em;
+  }
+
+  caption {
+    font-style: italic;
+  }
+`;
+
+const AboutPage = () => (
+  <Layout>
+    <SEO
+      title="About"
+      description="Learn about the Vera Rubin Observatory technical documentation portal, and the content that is currently available."
+    />
+
+    <h1>About the technical documentation portal</h1>
+
+    <h2 id="purpose">Purpose</h2>
+
+    <p>
+      The goal of this documentation portal is to help you access and discover
+      the Rubin Observatory’s public technical documentation. This portal is
+      available to everyone: the observatory team, the astronomy community, and
+      the general public.
+    </p>
+
+    <p>
+      Although there may be some public technical documentation that is not yet
+      available through this search portal, we index all our technote document
+      series, and are adding new sources all the time. See{' '}
+      <a href="#content-coverage">the content coverage table</a>, below for
+      details.
+    </p>
+
+    <p>
+      <em>
+        Documentation that isn’t public is beyond the scope of this portal.
+      </em>{' '}
+      Observatory team members should log into individual platforms to find
+      non-public information, such as{' '}
+      <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">
+        DocuShare
+      </a>
+      , <a href="https://jira.lsstcorp.org/secure/Dashboard.jspa">Jira</a>,{' '}
+      <a href="https://confluence.lsstcorp.org">Confluence</a>, or the{' '}
+      <a href="https://project.lsst.org/">Project homepage</a>.
+    </p>
+
+    <h2 id="content-coverage">Content coverage</h2>
+
+    <p>
+      Content types are added systematically as we develop our content indexer,{' '}
+      <a href="https://github.com/lsst-sqre/ook">Ook</a>. The following table
+      summarizes the types of content that are currently available through the
+      portal, along with content types that we anticipate adding in the future.
+    </p>
+
+    <ContentTable>
+      <caption>Status of content availability in this portal.</caption>
+      <thead>
+        <tr>
+          <th className="col-category"></th>
+          <th className="col-type" scope="col">
+            Content type
+          </th>
+          <th className="col-check" scope="col">
+            Search{' '}
+            <sup>
+              <a href="#content-types-fn1">[1]</a>
+            </sup>
+          </th>
+          <th className="col-check" scope="col">
+            Browse{' '}
+            <sup>
+              <a href="#content-types-fn2">[2]</a>
+            </sup>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th className="category" rowSpan="11" scope="row">
+            Documents
+          </th>
+          <td>Technical notes on lsst.io &mdash; LaTeX</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>Technical notes on lsst.io &mdash; rst format</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>DMTR &mdash; lsst.io</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>DMTR &mdash; DocuShare (public)</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>LDM &mdash; lsst.io</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>LDM &mdash; DocuShare (public)</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>LPM &mdash; lsst.io</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>LPM &mdash; DocuShare (public)</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>LSE &mdash; lsst.io</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>LSE &mdash; DocuShare (public)</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>Zenodo &mdash; lsst-dm community</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <th className="category" scope="row">
+            Guides
+          </th>
+          <td>Sphinx-based guides &mdash; lsst.io</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <th className="category" scope="row" rowSpan="2">
+            Discussions
+          </th>
+          <td>Community forum (public)</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>DM RFC (public)</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <th className="category" scope="row">
+            Software
+          </th>
+          <td>GitHub repositories</td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <th className="category" scope="row">
+            Misc.
+          </th>
+          <td>Glossary terms</td>
+          <td></td>
+          <td></td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <td colSpan="4" id="content-types-fn1">
+            <sup>[1]</sup> “Search” means the full text content is searchable
+            from the Advanced search page.
+          </td>
+        </tr>
+        <tr>
+          <td colSpan="4" id="content-types-fn2">
+            <sup>[2]</sup> “Browse” means the entity is linked from a page on
+            this portal.
+          </td>
+        </tr>
+      </tfoot>
+    </ContentTable>
+  </Layout>
+);
+
+export default AboutPage;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -184,7 +184,8 @@ const IndexPage = () => (
           <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">
             DocuShare
           </a>{' '}
-          are not yet part of the search results.
+          are not yet part of the search results.{' '}
+          <Link to="/about/">Learn more.</Link>
         </small>
       </p>
     </section>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -88,7 +88,7 @@ const IndexPage = () => (
       <StyledSearchContainer>
         <div className="wrapper">
           <div className="principal">
-            <h1>Find Rubin Observatory docs and open source</h1>
+            <h1>Find Rubin Observatory technical docs and software.</h1>
 
             <HeroSearchForm role="search" />
           </div>
@@ -100,7 +100,7 @@ const IndexPage = () => (
 
       <p>
         <Link to="/search/?hierarchicalMenu[contentCategories.lvl0]=Documents">
-          Search in all Rubin Observatory documents,
+          Search in Rubin Observatory technical documents,
         </Link>{' '}
         or browse by series:
       </p>

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -87,10 +87,7 @@ const AdvancedSearchPage = ({ location }) => {
       <SEO title="Advanced search" />
       <h1>Advanced search</h1>
 
-      <p>
-        Search the entire universe of Rubin Observatory documentation and open
-        source projects.
-      </p>
+      <p>Search in Rubin Observatory technical documentation.</p>
 
       <InstantSearch
         searchClient={searchClient}

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'gatsby';
 import algoliasearch from 'algoliasearch/lite';
 import { InstantSearch, Configure } from 'react-instantsearch-dom';
 import qs from 'qs';
@@ -87,7 +88,11 @@ const AdvancedSearchPage = ({ location }) => {
       <SEO title="Advanced search" />
       <h1>Advanced search</h1>
 
-      <p>Search in Rubin Observatory technical documentation.</p>
+      <p>
+        Search in Rubin Observatory technical documentation.{' '}
+        <Link to="/about">Learn more</Link> about what content is currently
+        available.
+      </p>
 
       <InstantSearch
         searchClient={searchClient}


### PR DESCRIPTION
- Change the phrasing of "docs" to "technical docs" because it minimizes the potential for confusion that management or private documentation is available from the site.
- Add an "About page" that explains the purpose of the site and what content is available. Draft: https://search-demo.lsst.io/about/
- Link to the about page from multiple pages:
  - Homepage: https://search-demo.lsst.io
  - Advanced search page: https://search-demo.lsst.io/search/
  - Category pages that may be content in DocuShare: https://search-demo.lsst.io/ldm/