### PR TITLE
DM-26002: Add a CurrentRefinements widget to search UI

### DIFF
--- a/src/components/globalStyles.js
+++ b/src/components/globalStyles.js
@@ -159,6 +159,7 @@ const GlobalStyle = createGlobalStyle`
     --c-alternate-layer-background: var(--c-neutral-800);
     --c-alternate-layer-text: var(--c-reversed-text);
     --c-alternate-layer-link: var(--c-reversed-link);
+    --c-delete: var(--c-red-500);
 
     /*
      * Elevations
@@ -243,6 +244,7 @@ const GlobalStyle = createGlobalStyle`
     --c-algolia-text: var(--c-text);
     --c-table-row-highlight: var(--c-cyan-900);
     --c-table-border: var(--c-text);
+    --c-delete: var(--c-red-300);
   }
 
   a {

--- a/src/components/instantsearch/clearRefinements.js
+++ b/src/components/instantsearch/clearRefinements.js
@@ -10,11 +10,16 @@ import { connectCurrentRefinements } from 'react-instantsearch-dom';
 
 import Button from '../basics/buttons';
 
-const ClearRefinementsCore = ({ items, refine }) => (
-  <Button onClick={() => refine(items)} disabled={!items.length}>
-    Clear all refinements
-  </Button>
-);
+const ClearRefinementsCore = ({ items, refine }) => {
+  if (items.length) {
+    return (
+      <Button onClick={() => refine(items)} disabled={!items.length}>
+        Clear all refinements
+      </Button>
+    );
+  }
+  return null;
+};
 
 ClearRefinementsCore.propTypes = {
   items: PropTypes.array.isRequired,

--- a/src/components/instantsearch/currentRefinements.js
+++ b/src/components/instantsearch/currentRefinements.js
@@ -4,10 +4,41 @@
  * https://www.algolia.com/doc/api-reference/widgets/current-refinements/react/
  */
 
+import React from 'react';
 import styled from 'styled-components';
 import { CurrentRefinements as CurrentRefinementsCore } from 'react-instantsearch-dom';
 
-const CurrentRefinements = styled(CurrentRefinementsCore)`
+/**
+ * Custom prefixes for item labels.
+ *
+ * First items in the individual arrays are the prefixes of labels, not
+ * including the ":". The second items are replacement values for those
+ * prefixes.
+ */
+const labelPrefixes = [
+  ['authorNames', 'Contributors'],
+  ['contentCategories.lvl0', 'Content type'],
+];
+const labelPrefixMap = new Map(labelPrefixes);
+
+/**
+ * Transforms the label attribute of a refinement items to use a customized
+ * label from labelPrefixes.
+ *
+ * This function identifies refinements based on the prefix for the label,
+ * which is the text before the ":".
+ */
+export const itemTransformer = items =>
+  items.map(item => {
+    const labelParts = item.label.split(':', 2);
+    const suggestedPrefix = labelPrefixMap.get(labelParts[0]);
+    if (suggestedPrefix) {
+      item.label = `${suggestedPrefix}: ${labelParts[1]}`;
+    }
+    return item;
+  });
+
+const StyledCurrentRefinements = styled(CurrentRefinementsCore)`
   margin-top: var(--space-xxs);
 
   .ais-CurrentRefinements-item {
@@ -28,5 +59,15 @@ const CurrentRefinements = styled(CurrentRefinementsCore)`
     color: var(--c-delete);
   }
 `;
+
+/**
+ * All-inclusive version of the CurrentRefinements instant search widget
+ * that includes custom styling and label transformations.
+ */
+const CurrentRefinements = () => (
+  <>
+    <StyledCurrentRefinements transformItems={itemTransformer} />
+  </>
+);
 
 export default CurrentRefinements;

--- a/src/components/instantsearch/currentRefinements.js
+++ b/src/components/instantsearch/currentRefinements.js
@@ -1,0 +1,32 @@
+/*
+ * Styled version of the Algolia InstantSearch CurrentRefinements component.
+ *
+ * https://www.algolia.com/doc/api-reference/widgets/current-refinements/react/
+ */
+
+import styled from 'styled-components';
+import { CurrentRefinements as CurrentRefinementsCore } from 'react-instantsearch-dom';
+
+const CurrentRefinements = styled(CurrentRefinementsCore)`
+  margin-top: var(--space-xxs);
+
+  .ais-CurrentRefinements-item {
+    border-radius: var(--border-radius-1);
+    padding: var(--space-xxxs-fixed) var(--space-xs-fixed);
+    background-color: var(--c-tag-background);
+  }
+
+  .ais-CurrentRefinements-label,
+  .ais-CurrentRefinements-categoryLabel,
+  .ais-CurrentRefinements-delete {
+    color: var(--c-text);
+    font-size: 0.8rem;
+    transition: 0.3s ease color;
+  }
+
+  .ais-CurrentRefinements-delete:hover {
+    color: var(--c-delete);
+  }
+`;
+
+export default CurrentRefinements;

--- a/src/components/instantsearch/searchBox.js
+++ b/src/components/instantsearch/searchBox.js
@@ -1,0 +1,29 @@
+/*
+ * Styled SearchBox that includes the PoweredBy widget.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { SearchBox as SearchBoxCore } from 'react-instantsearch-dom';
+
+import PoweredBy from './poweredBy';
+
+const SearchBoxContainer = styled.div`
+  display: flex; /* Lay out box+powered by in line */
+`;
+
+/* SearchBox Algolia InstantSearch widget that's styled.
+ * https://www.algolia.com/doc/api-reference/widgets/search-box/react/
+ */
+export const StyledSearchBoxCore = styled(SearchBoxCore)`
+  flex: 1 1 0;
+`;
+
+const SearchBox = () => (
+  <SearchBoxContainer>
+    <StyledSearchBoxCore autoFocus />
+    <PoweredBy />
+  </SearchBoxContainer>
+);
+
+export default SearchBox;

--- a/src/components/pageLayer.js
+++ b/src/components/pageLayer.js
@@ -17,7 +17,6 @@ const PageLayer = styled.section`
   margin-top: 0;
   margin-bottom: 0;
   padding: var(--space-lg) 0;
-  box-shadow: var(--elevation-lg);
 
   h1,
   h2,

--- a/src/components/searchLayout.js
+++ b/src/components/searchLayout.js
@@ -1,7 +1,6 @@
 /* Layout for the Algolia search UI. */
 
 import styled from 'styled-components';
-import { SearchBox } from 'react-instantsearch-dom';
 
 import bp from '../design/breakpoints';
 
@@ -22,16 +21,8 @@ export const SearchLayout = styled.div`
 `;
 
 export const SearchBoxArea = styled.div`
-  display: flex; /* Lay out box+powered by in line */
   grid-column: 2 / 3;
   grid-row: 1 / 2;
-`;
-
-/* SearchBox Algolia InstantSearch widget that's styled.
- * https://www.algolia.com/doc/api-reference/widgets/search-box/react/
- */
-export const StyledSearchBox = styled(SearchBox)`
-  flex: 1 1 0;
 `;
 
 export const SearchRefinementsArea = styled.div`

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -15,10 +15,9 @@ import {
   SearchResultsArea,
   SearchBoxArea,
   SearchRefinementsArea,
-  StyledSearchBox,
   SearchRefinementSection,
 } from '../components/searchLayout';
-import PoweredBy from '../components/instantsearch/poweredBy';
+import SearchBox from '../components/instantsearch/searchBox';
 import RefinementList from '../components/instantsearch/refinementList';
 import HierarchicalMenu from '../components/instantsearch/hierarchicalMenu';
 import ClearRefinements from '../components/instantsearch/clearRefinements';
@@ -109,8 +108,7 @@ const AdvancedSearchPage = ({ location }) => {
 
         <SearchLayout>
           <SearchBoxArea>
-            <StyledSearchBox autoFocus />
-            <PoweredBy />
+            <SearchBox />
           </SearchBoxArea>
 
           <SearchRefinementsArea>

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -21,6 +21,7 @@ import SearchBox from '../components/instantsearch/searchBox';
 import RefinementList from '../components/instantsearch/refinementList';
 import HierarchicalMenu from '../components/instantsearch/hierarchicalMenu';
 import ClearRefinements from '../components/instantsearch/clearRefinements';
+import CurrentRefinements from '../components/instantsearch/currentRefinements';
 import NonEmptyHits from '../components/instantsearch/nonEmptyHits';
 import DetailsToggleButton from '../components/detailsToggle';
 import SearchSettingsCluster from '../components/searchSettingsCluster';
@@ -109,6 +110,7 @@ const AdvancedSearchPage = ({ location }) => {
         <SearchLayout>
           <SearchBoxArea>
             <SearchBox />
+            <CurrentRefinements />
           </SearchBoxArea>
 
           <SearchRefinementsArea>

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -20,7 +20,6 @@ import {
 import SearchBox from '../components/instantsearch/searchBox';
 import RefinementList from '../components/instantsearch/refinementList';
 import HierarchicalMenu from '../components/instantsearch/hierarchicalMenu';
-import ClearRefinements from '../components/instantsearch/clearRefinements';
 import CurrentRefinements from '../components/instantsearch/currentRefinements';
 import NonEmptyHits from '../components/instantsearch/nonEmptyHits';
 import DetailsToggleButton from '../components/detailsToggle';
@@ -137,7 +136,6 @@ const AdvancedSearchPage = ({ location }) => {
                   hitCardsExpanded={hitCardsExpanded}
                   setHitCardsExpanded={setHitCardsExpanded}
                 />
-                <ClearRefinements />
               </div>
             </SearchSettingsCluster>
             <NonEmptyHits

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -22,7 +22,6 @@ import {
 } from '../components/searchLayout';
 import SearchBox from '../components/instantsearch/searchBox';
 import RefinementList from '../components/instantsearch/refinementList';
-import ClearRefinements from '../components/instantsearch/clearRefinements';
 import CurrentRefinements from '../components/instantsearch/currentRefinements';
 import { StyledHits } from '../components/instantsearch/hits';
 import DetailsToggleButton from '../components/detailsToggle';
@@ -143,7 +142,6 @@ export default function DocSeriesTemplate({
                   hitCardsExpanded={hitCardsExpanded}
                   setHitCardsExpanded={setHitCardsExpanded}
                 />
-                <ClearRefinements />
               </div>
             </SearchSettingsCluster>
 

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -18,10 +18,9 @@ import {
   SearchResultsArea,
   SearchBoxArea,
   SearchRefinementsArea,
-  StyledSearchBox,
   SearchRefinementSection,
 } from '../components/searchLayout';
-import PoweredBy from '../components/instantsearch/poweredBy';
+import SearchBox from '../components/instantsearch/searchBox';
 import RefinementList from '../components/instantsearch/refinementList';
 import ClearRefinements from '../components/instantsearch/clearRefinements';
 import { StyledHits } from '../components/instantsearch/hits';
@@ -117,8 +116,7 @@ export default function DocSeriesTemplate({
 
         <SearchLayout>
           <SearchBoxArea>
-            <StyledSearchBox autoFocus />
-            <PoweredBy />
+            <SearchBox />
           </SearchBoxArea>
 
           <SearchRefinementsArea>

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -23,6 +23,7 @@ import {
 import SearchBox from '../components/instantsearch/searchBox';
 import RefinementList from '../components/instantsearch/refinementList';
 import ClearRefinements from '../components/instantsearch/clearRefinements';
+import CurrentRefinements from '../components/instantsearch/currentRefinements';
 import { StyledHits } from '../components/instantsearch/hits';
 import DetailsToggleButton from '../components/detailsToggle';
 import SearchSettingsCluster from '../components/searchSettingsCluster';
@@ -117,6 +118,7 @@ export default function DocSeriesTemplate({
         <SearchLayout>
           <SearchBoxArea>
             <SearchBox />
+            <CurrentRefinements />
           </SearchBoxArea>
 
           <SearchRefinementsArea>


### PR DESCRIPTION
This PR replaces the ClearRefinements widget with the CurrentRefinements widget. The advantage of this new widget is that it shows what refinements are active and lets the user clear them individually. We don't have enough refinements currently to justify an additional ClearRefinements widget, but we could bring it back.

When there are no refinements, no UI is present (unlike the previous solution where the "Clear all refinements" button was always present.

A complication of this implementation is the need to map refinement labels to human-readable names (e.g. `contentCategories.lvl0` to `Content type`). This is accomplished with a mapping inside the currentRefinements.js module. As more refinements are added to search interfaces, we'll need to expand that mapping.

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/349384/89586696-30e9ec80-d80e-11ea-93aa-295669814584.png">
