### PR TITLE
DM-26291: Force trailing slashes for NavGrid links

### DIFF
--- a/src/components/navGrid.js
+++ b/src/components/navGrid.js
@@ -38,7 +38,7 @@ const NavCardContainer = styled.div`
 
 const NavCard = ({ slug, title, description }) => (
   <NavCardContainer>
-    <Link to={slug}>
+    <Link to={`/${slug}/`}>
       <h3>{title}</h3>
     </Link>
     <p>{description}</p>


### PR DESCRIPTION
This will ensure that the canonical URLs for these pages have trailing slashes. These trailing slashes are needed for compatibility with the Algolia instantsearch URL state syncing.