### PR TITLE
DM-27019: Delete OPSTN series homepage

### DIFF
--- a/src/data/docSeries.yaml
+++ b/src/data/docSeries.yaml
@@ -33,9 +33,6 @@
     Documents held only in <a href="https://docushare.lsstcorp.org/docushare/dsweb/HomePage">DocuShare</a> are not yet included in these results. <a href="/about/">Learn more</a>.
 
 
-- key: OPSTN
-  name: Operations Technotes
-
 - key: PSTN
   name: Project Science Team Technotes
 


### PR DESCRIPTION
This series is now deprecated and replaced by RTN.