### PR TITLE
DM-31745: Filter by creation/update dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@wojtekmaj/react-daterange-picker": "^3.3.0",
         "algoliasearch": "^4.10.5",
         "babel-plugin-styled-components": "^1.13.2",
         "gatsby": "^3.13.0",
@@ -3388,6 +3389,14 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-calendar": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/react-calendar/-/react-calendar-3.4.3.tgz",
+      "integrity": "sha512-k56OS9d62/g3OCTepULEpNoClVUKuWxHBBuKS4hX8/qNiNup+Gf1Qn0SXHakbqBGWEfdLK93RlIRy5XOA4+Iaw==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -3867,6 +3876,34 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.0.3.tgz",
+      "integrity": "sha512-1VPkkTBk07gMR1fjpBtse4G+oJqpmE+0gUFB0dg3VIL7qJmUVaBoD/vlzMm/jNeOPfvlmerl1lpnsZyBUFIRuw==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
+      }
+    },
+    "node_modules/@wojtekmaj/react-daterange-picker": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/react-daterange-picker/-/react-daterange-picker-3.3.0.tgz",
+      "integrity": "sha512-RdxBGRCTC+90SHfd+kMIcIKjmQZzdWSjW2v1Y/45r0DxW0H+1V/y/T3CMOEjvrKCleIjTde0bmpnHbF2jHsZJw==",
+      "dependencies": {
+        "make-event-props": "^1.1.0",
+        "merge-class-names": "^1.1.1",
+        "prop-types": "^15.6.0",
+        "react-calendar": "^3.3.1",
+        "react-date-picker": "^8.3.2",
+        "react-fit": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-daterange-picker?sponsor=1"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0-0",
+        "react-dom": "^16.3.0 || ^17.0.0-0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -6805,6 +6842,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "node_modules/detect-element-overflow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/detect-element-overflow/-/detect-element-overflow-1.2.0.tgz",
+      "integrity": "sha512-Jtr9ivYPhpd9OJux+hjL0QjUKiS1Ghgy8tvIufUjFslQgIWvgGr4mn57H190APbKkiOmXnmtMI6ytaKzMusecg=="
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
@@ -11588,6 +11630,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-1.4.0.tgz",
+      "integrity": "sha512-gQo03lP1OArHLKlnoglqrGGl7b04u2EP9Xutmp72cMdtrrSD7ZgIsCsUKZynYWLDkVJW33Cj3pliP7uP0UonHQ==",
+      "dependencies": {
+        "lodash.once": "^4.1.1"
+      }
+    },
     "node_modules/get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -14064,6 +14114,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
     "node_modules/lodash.template": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
@@ -14266,6 +14321,11 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "node_modules/make-event-props": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.2.0.tgz",
+      "integrity": "sha512-BmWFkm/jZzVH9A0tEBdkjAARUz/eha+5IRyfOndeSMKRadkgR5DawoBHoRwLxkYmjJOI5bHkXKpaZocxj+dKgg=="
     },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
@@ -14508,10 +14568,23 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
+    "node_modules/merge-class-names": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.4.2.tgz",
+      "integrity": "sha512-bOl98VzwCGi25Gcn3xKxnR5p/WrhWFQB59MS/aGENcmUc6iSm96yrFDF0XSNurX9qN4LbJm0R9kfvsQ17i8zCw==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/merge-class-names?sponsor=1"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "node_modules/merge-refs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.0.0.tgz",
+      "integrity": "sha512-WZ4S5wqD9FCR9hxkLgvcHJCBxzXzy3VVE6p8W2OzxRzB+hLRlcadGE2bW9xp2KSzk10rvp4y+pwwKO6JQVguMg=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -17396,6 +17469,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-calendar": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-3.4.0.tgz",
+      "integrity": "sha512-ykbvXASArQQ8KZlCEXEdE+w+KFGSj7kDpdTRzbLVJeN26oUIu+EFavFDAqg4G//zTO0tSq5SMfqAa6fjrdGQjQ==",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^1.0.2",
+        "get-user-locale": "^1.2.0",
+        "merge-class-names": "^1.1.1",
+        "prop-types": "^15.6.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0-0",
+        "react-dom": "^16.3.0 || ^17.0.0-0"
+      }
+    },
+    "node_modules/react-date-picker": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/react-date-picker/-/react-date-picker-8.3.2.tgz",
+      "integrity": "sha512-lcuW8GD6yIfsoYQjdBDfVChY4GR9sDjcm3gr/Q/1g6QPrCWnsHFh/RBs7iy0MMe/yYCtmQM6kaoECBU0s6/FpQ==",
+      "dependencies": {
+        "@types/react-calendar": "^3.0.0",
+        "@wojtekmaj/date-utils": "^1.0.3",
+        "get-user-locale": "^1.2.0",
+        "make-event-props": "^1.1.0",
+        "merge-class-names": "^1.1.1",
+        "merge-refs": "^1.0.0",
+        "prop-types": "^15.6.0",
+        "react-calendar": "^3.3.1",
+        "react-fit": "^1.0.3",
+        "update-input-width": "^1.2.2"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-date-picker?sponsor=1"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0-0",
+        "react-dom": "^16.3.0 || ^17.0.0-0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",
@@ -17689,6 +17804,22 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "node_modules/react-fit": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-fit/-/react-fit-1.3.1.tgz",
+      "integrity": "sha512-MmVk/SXyVbxiz9peAeD7fWxFdGLoy/sCxte01M3w74regPIVkLqc2yT0wUAGRd1MNP1fQ40MqYKNBLpbK/aI1w==",
+      "dependencies": {
+        "detect-element-overflow": "^1.2.0",
+        "prop-types": "^15.6.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-fit?sponsor=1"
+      },
+      "peerDependencies": {
+        "react": ">=15.5",
+        "react-dom": ">=15.5"
+      }
     },
     "node_modules/react-helmet": {
       "version": "6.1.0",
@@ -20727,6 +20858,14 @@
       "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/update-input-width": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/update-input-width/-/update-input-width-1.2.2.tgz",
+      "integrity": "sha512-6QwD9ZVSXb96PxOZ01DU0DJTPwQGY7qBYgdniZKJN02Xzom2m+9J6EPxMbefskqtj4x78qbe5psDSALq9iNEYg==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/update-input-width?sponsor=1"
       }
     },
     "node_modules/update-notifier": {
@@ -24467,6 +24606,14 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/react-calendar": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/react-calendar/-/react-calendar-3.4.3.tgz",
+      "integrity": "sha512-k56OS9d62/g3OCTepULEpNoClVUKuWxHBBuKS4hX8/qNiNup+Gf1Qn0SXHakbqBGWEfdLK93RlIRy5XOA4+Iaw==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -24829,6 +24976,24 @@
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "@wojtekmaj/date-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.0.3.tgz",
+      "integrity": "sha512-1VPkkTBk07gMR1fjpBtse4G+oJqpmE+0gUFB0dg3VIL7qJmUVaBoD/vlzMm/jNeOPfvlmerl1lpnsZyBUFIRuw=="
+    },
+    "@wojtekmaj/react-daterange-picker": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/react-daterange-picker/-/react-daterange-picker-3.3.0.tgz",
+      "integrity": "sha512-RdxBGRCTC+90SHfd+kMIcIKjmQZzdWSjW2v1Y/45r0DxW0H+1V/y/T3CMOEjvrKCleIjTde0bmpnHbF2jHsZJw==",
+      "requires": {
+        "make-event-props": "^1.1.0",
+        "merge-class-names": "^1.1.1",
+        "prop-types": "^15.6.0",
+        "react-calendar": "^3.3.1",
+        "react-date-picker": "^8.3.2",
+        "react-fit": "^1.0.3"
       }
     },
     "@xtuc/ieee754": {
@@ -27107,6 +27272,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-element-overflow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/detect-element-overflow/-/detect-element-overflow-1.2.0.tgz",
+      "integrity": "sha512-Jtr9ivYPhpd9OJux+hjL0QjUKiS1Ghgy8tvIufUjFslQgIWvgGr4mn57H190APbKkiOmXnmtMI6ytaKzMusecg=="
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -30698,6 +30868,14 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "get-user-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-1.4.0.tgz",
+      "integrity": "sha512-gQo03lP1OArHLKlnoglqrGGl7b04u2EP9Xutmp72cMdtrrSD7ZgIsCsUKZynYWLDkVJW33Cj3pliP7uP0UonHQ==",
+      "requires": {
+        "lodash.once": "^4.1.1"
+      }
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -32542,6 +32720,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
     "lodash.template": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
@@ -32704,6 +32887,11 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "make-event-props": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.2.0.tgz",
+      "integrity": "sha512-BmWFkm/jZzVH9A0tEBdkjAARUz/eha+5IRyfOndeSMKRadkgR5DawoBHoRwLxkYmjJOI5bHkXKpaZocxj+dKgg=="
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -32880,10 +33068,20 @@
         }
       }
     },
+    "merge-class-names": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.4.2.tgz",
+      "integrity": "sha512-bOl98VzwCGi25Gcn3xKxnR5p/WrhWFQB59MS/aGENcmUc6iSm96yrFDF0XSNurX9qN4LbJm0R9kfvsQ17i8zCw=="
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge-refs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.0.0.tgz",
+      "integrity": "sha512-WZ4S5wqD9FCR9hxkLgvcHJCBxzXzy3VVE6p8W2OzxRzB+hLRlcadGE2bW9xp2KSzk10rvp4y+pwwKO6JQVguMg=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -34952,6 +35150,34 @@
         "object-assign": "^4.1.1"
       }
     },
+    "react-calendar": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-3.4.0.tgz",
+      "integrity": "sha512-ykbvXASArQQ8KZlCEXEdE+w+KFGSj7kDpdTRzbLVJeN26oUIu+EFavFDAqg4G//zTO0tSq5SMfqAa6fjrdGQjQ==",
+      "requires": {
+        "@wojtekmaj/date-utils": "^1.0.2",
+        "get-user-locale": "^1.2.0",
+        "merge-class-names": "^1.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-date-picker": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/react-date-picker/-/react-date-picker-8.3.2.tgz",
+      "integrity": "sha512-lcuW8GD6yIfsoYQjdBDfVChY4GR9sDjcm3gr/Q/1g6QPrCWnsHFh/RBs7iy0MMe/yYCtmQM6kaoECBU0s6/FpQ==",
+      "requires": {
+        "@types/react-calendar": "^3.0.0",
+        "@wojtekmaj/date-utils": "^1.0.3",
+        "get-user-locale": "^1.2.0",
+        "make-event-props": "^1.1.0",
+        "merge-class-names": "^1.1.1",
+        "merge-refs": "^1.0.0",
+        "prop-types": "^15.6.0",
+        "react-calendar": "^3.3.1",
+        "react-fit": "^1.0.3",
+        "update-input-width": "^1.2.2"
+      }
+    },
     "react-dev-utils": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",
@@ -35170,6 +35396,15 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "react-fit": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-fit/-/react-fit-1.3.1.tgz",
+      "integrity": "sha512-MmVk/SXyVbxiz9peAeD7fWxFdGLoy/sCxte01M3w74regPIVkLqc2yT0wUAGRd1MNP1fQ40MqYKNBLpbK/aI1w==",
+      "requires": {
+        "detect-element-overflow": "^1.2.0",
+        "prop-types": "^15.6.0"
+      }
     },
     "react-helmet": {
       "version": "6.1.0",
@@ -37531,6 +37766,11 @@
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         }
       }
+    },
+    "update-input-width": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/update-input-width/-/update-input-width-1.2.2.tgz",
+      "integrity": "sha512-6QwD9ZVSXb96PxOZ01DU0DJTPwQGY7qBYgdniZKJN02Xzom2m+9J6EPxMbefskqtj4x78qbe5psDSALq9iNEYg=="
     },
     "update-notifier": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     }
   },
   "dependencies": {
+    "@wojtekmaj/react-daterange-picker": "^3.3.0",
     "algoliasearch": "^4.10.5",
     "babel-plugin-styled-components": "^1.13.2",
     "gatsby": "^3.13.0",

--- a/src/components/documentHit.js
+++ b/src/components/documentHit.js
@@ -14,6 +14,7 @@ import { IconDataListTerm, IconDataListContent } from './basics/iconDataList';
 import UserCoupleIcon from '../icons/user-couple.svg';
 import TimeIcon from '../icons/time.svg';
 import CodeIcon from '../icons/code.svg';
+import HistoryIcon from '../icons/history.svg';
 import VisuallyHidden from './basics/visuallyHidden';
 
 const DocumentHitContainer = styled.div`
@@ -97,7 +98,7 @@ const Summary = styled.div`
 
 const PersonList = ({ className, names }) => (
   <ol className={className}>
-    {names.map(name => (
+    {names.map((name) => (
       <li key={name}>{name}</li>
     ))}
   </ol>
@@ -186,13 +187,30 @@ const StyledCodeIcon = styled(CodeIcon)`
   }
 `;
 
-const humanizeAge = timestamp => {
-  const t = moment(timestamp);
+const StyledHistoryIcon = styled(HistoryIcon)`
+  width: 0.85em;
+  width: 1cap;
+  height: 0.85em;
+  height: 1cap;
+
+  /* secondary and primary look better reversed */
+  .secondary {
+    fill: var(--c-icon-secondary);
+  }
+
+  .primary {
+    fill: var(--c-icon-secondary);
+  }
+`;
+
+const humanizeAge = (timestamp) => {
+  const t = moment.unix(timestamp).utc();
   const age = moment.duration(t.diff(moment()));
+  const formattedDate = t.format('YYYY-MM-DD');
   return (
-    <time dateTime={timestamp}>{`${age.humanize(true)} (${t.format(
-      'YYYY-MM-DD'
-    )})`}</time>
+    <time dateTime={formattedDate}>{`${age.humanize(
+      true
+    )} (${formattedDate})`}</time>
   );
 };
 
@@ -249,14 +267,26 @@ const DocumentHit = ({ hit, expanded }) => (
           </>
         )}
 
-        {hit.sourceUpdateTime && (
+        {hit.sourceUpdateTimestamp && (
           <>
             <IconDataListTerm>
               <StyledTimeIcon />
-              <VisuallyHidden>Updated on</VisuallyHidden>
+              <VisuallyHidden>Date updated</VisuallyHidden>
             </IconDataListTerm>
             <IconDataListContent>
-              {humanizeAge(hit.sourceUpdateTime)}
+              Updated {humanizeAge(hit.sourceUpdateTimestamp)}
+            </IconDataListContent>
+          </>
+        )}
+
+        {hit.sourceCreationTimestamp && (
+          <>
+            <IconDataListTerm>
+              <StyledHistoryIcon />
+              <VisuallyHidden>Date created</VisuallyHidden>
+            </IconDataListTerm>
+            <IconDataListContent>
+              Created {humanizeAge(hit.sourceCreationTimestamp)}
             </IconDataListContent>
           </>
         )}

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -44,7 +44,7 @@ const Footer = () => (
           </li>
           <li>
             <a href="slack://channel?team=T06D204F2&id=C2B6DQBAL">
-              Chat in #dm-docs on Slack (internal)
+              Chat in #dm-docs-support on Slack (internal)
             </a>
           </li>
         </ul>

--- a/src/components/instantsearch/currentRefinements.js
+++ b/src/components/instantsearch/currentRefinements.js
@@ -18,8 +18,18 @@ import { CurrentRefinements as CurrentRefinementsCore } from 'react-instantsearc
 const labelPrefixes = [
   ['authorNames', 'Contributors'],
   ['contentCategories.lvl0', 'Content type'],
+  ['sourceCreationTimestamp', 'Created'],
+  ['sourceUpdateTimestamp', 'Updated'],
 ];
 const labelPrefixMap = new Map(labelPrefixes);
+
+/**
+ * Attributes that use date-range based formatting
+ */
+const dateRangeAttributes = [
+  'sourceCreationTimestamp',
+  'sourceUpdateTimestamp',
+];
 
 /**
  * Transforms the label attribute of a refinement items to use a customized
@@ -28,12 +38,22 @@ const labelPrefixMap = new Map(labelPrefixes);
  * This function identifies refinements based on the prefix for the label,
  * which is the text before the ":".
  */
-export const itemTransformer = items =>
-  items.map(item => {
-    const labelParts = item.label.split(':', 2);
-    const suggestedPrefix = labelPrefixMap.get(labelParts[0]);
-    if (suggestedPrefix) {
-      item.label = `${suggestedPrefix}: ${labelParts[1]}`;
+export const itemTransformer = (items) =>
+  items.map((item) => {
+    if (dateRangeAttributes.includes(item.attribute)) {
+      // Labels for date ranges
+      const startDate = new Date(item.currentRefinement.min * 1000);
+      const endDate = new Date(item.currentRefinement.max * 1000);
+      item.label = `${labelPrefixMap.get(
+        item.attribute
+      )}: ${startDate.toDateString()} to ${endDate.toDateString()}`;
+    } else {
+      // Default case: labels for string refinements
+      const labelParts = item.label.split(':', 2);
+      const suggestedPrefix = labelPrefixMap.get(item.attribute);
+      if (suggestedPrefix) {
+        item.label = `${suggestedPrefix}: ${labelParts[1]}`;
+      }
     }
     return item;
   });

--- a/src/components/instantsearch/currentRefinements.js
+++ b/src/components/instantsearch/currentRefinements.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { CurrentRefinements as CurrentRefinementsCore } from 'react-instantsearch-dom';
+import moment from 'moment';
 
 /**
  * Custom prefixes for item labels.
@@ -31,6 +32,8 @@ const dateRangeAttributes = [
   'sourceUpdateTimestamp',
 ];
 
+const formatDate = (date) => moment(date).format('YYYY-MM-DD');
+
 /**
  * Transforms the label attribute of a refinement items to use a customized
  * label from labelPrefixes.
@@ -44,9 +47,9 @@ export const itemTransformer = (items) =>
       // Labels for date ranges
       const startDate = new Date(item.currentRefinement.min * 1000);
       const endDate = new Date(item.currentRefinement.max * 1000);
-      item.label = `${labelPrefixMap.get(
-        item.attribute
-      )}: ${startDate.toDateString()} to ${endDate.toDateString()}`;
+      item.label = `${labelPrefixMap.get(item.attribute)}: ${formatDate(
+        startDate
+      )} to ${formatDate(endDate)}`;
     } else {
       // Default case: labels for string refinements
       const labelParts = item.label.split(':', 2);

--- a/src/components/instantsearch/dateRangeInput.js
+++ b/src/components/instantsearch/dateRangeInput.js
@@ -6,26 +6,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connectRange } from 'react-instantsearch-dom';
+import DateRangePicker from '@wojtekmaj/react-daterange-picker';
 
 /**
  * Min/max date range selector component.
  */
-const DateRangeInputCore = ({ currentRefinement, min, max, refine }) => {
-  console.log(currentRefinement);
-  console.log(min);
-  console.log(max);
-  console.log(refine);
-  return (
-    <div>
-      {currentRefinement.min} to {currentRefinement.max}
-    </div>
-  );
-};
+const DateRangeInputCore = ({ currentRefinement, refine }) => (
+  <div>
+    <DateRangePicker
+      disableCalendar
+      rangeDivider=" to  "
+      onChange={(newValue) =>
+        refine({
+          min: newValue[0].getTime() / 1000,
+          max: newValue[1].getTime() / 1000,
+        })
+      }
+      value={[
+        new Date(currentRefinement.min * 1000),
+        new Date(currentRefinement.max * 1000),
+      ]}
+    />
+  </div>
+);
 
 DateRangeInputCore.propTypes = {
   currentRefinement: PropTypes.object.isRequired,
-  min: PropTypes.number.isRequired,
-  max: PropTypes.number.isRequired,
   refine: PropTypes.func.isRequired,
 };
 

--- a/src/components/instantsearch/dateRangeInput.js
+++ b/src/components/instantsearch/dateRangeInput.js
@@ -3,42 +3,40 @@
  * a range of dates.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connectRange } from 'react-instantsearch-dom';
 import DateRangePicker from '@wojtekmaj/react-daterange-picker';
+
+import useDebounce from '../../hooks/useDebounce';
 
 /**
  * Min/max date range selector component.
  */
 const DateRangeInputCore = ({ currentRefinement, refine, min, max }) => {
-  const [dateRange, onChangeDateRange] = useState([
-    new Date(currentRefinement.min * 1000),
-    new Date(currentRefinement.max * 1000),
-  ]);
+  // Debouncing the current refinement ensures that the search results
+  // don't jump while trying to select dates.
+  const debouncedCurrentRefinement = useDebounce(currentRefinement, 1000);
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
+  const onChangeDateRange = (newRange) => {
     refine({
-      min: dateRange[0].getTime() / 1000,
-      max: dateRange[1].getTime() / 1000,
+      min: newRange[0].getTime() / 1000,
+      max: newRange[1].getTime() / 1000,
     });
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <DateRangePicker
-        disableCalendar
-        rangeDivider=" to "
-        onChange={onChangeDateRange}
-        value={dateRange}
-        minDate={new Date(min * 1000)}
-        maxDate={new Date(max * 1000)}
-      />
-      <button as="input" type="submit" aria-label="Filter">
-        Filter
-      </button>
-    </form>
+    <DateRangePicker
+      disableCalendar
+      rangeDivider=" to "
+      onChange={onChangeDateRange}
+      value={[
+        new Date(debouncedCurrentRefinement.min * 1000),
+        new Date(debouncedCurrentRefinement.max * 1000),
+      ]}
+      minDate={new Date(min * 1000)}
+      maxDate={new Date(max * 1000)}
+    />
   );
 };
 

--- a/src/components/instantsearch/dateRangeInput.js
+++ b/src/components/instantsearch/dateRangeInput.js
@@ -51,6 +51,7 @@ const DateRangeInputCore = ({ currentRefinement, refine, min, max }) => {
     <StyledDateRangePicker
       disableCalendar
       rangeDivider="to"
+      clearIcon={null}
       onChange={onChangeDateRange}
       value={[
         new Date(debouncedCurrentRefinement.min * 1000),

--- a/src/components/instantsearch/dateRangeInput.js
+++ b/src/components/instantsearch/dateRangeInput.js
@@ -3,7 +3,7 @@
  * a range of dates.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connectRange } from 'react-instantsearch-dom';
 import DateRangePicker from '@wojtekmaj/react-daterange-picker';
@@ -11,28 +11,42 @@ import DateRangePicker from '@wojtekmaj/react-daterange-picker';
 /**
  * Min/max date range selector component.
  */
-const DateRangeInputCore = ({ currentRefinement, refine }) => (
-  <div>
-    <DateRangePicker
-      disableCalendar
-      rangeDivider=" to  "
-      onChange={(newValue) =>
-        refine({
-          min: newValue[0].getTime() / 1000,
-          max: newValue[1].getTime() / 1000,
-        })
-      }
-      value={[
-        new Date(currentRefinement.min * 1000),
-        new Date(currentRefinement.max * 1000),
-      ]}
-    />
-  </div>
-);
+const DateRangeInputCore = ({ currentRefinement, refine, min, max }) => {
+  const [dateRange, onChangeDateRange] = useState([
+    new Date(currentRefinement.min * 1000),
+    new Date(currentRefinement.max * 1000),
+  ]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    refine({
+      min: dateRange[0].getTime() / 1000,
+      max: dateRange[1].getTime() / 1000,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <DateRangePicker
+        disableCalendar
+        rangeDivider=" to "
+        onChange={onChangeDateRange}
+        value={dateRange}
+        minDate={new Date(min * 1000)}
+        maxDate={new Date(max * 1000)}
+      />
+      <button as="input" type="submit" aria-label="Filter">
+        Filter
+      </button>
+    </form>
+  );
+};
 
 DateRangeInputCore.propTypes = {
   currentRefinement: PropTypes.object.isRequired,
   refine: PropTypes.func.isRequired,
+  min: PropTypes.number.isRequired,
+  max: PropTypes.number.isRequired,
 };
 
 const DateRangeInput = connectRange(DateRangeInputCore);

--- a/src/components/instantsearch/dateRangeInput.js
+++ b/src/components/instantsearch/dateRangeInput.js
@@ -19,10 +19,18 @@ const DateRangeInputCore = ({ currentRefinement, refine, min, max }) => {
   const debouncedCurrentRefinement = useDebounce(currentRefinement, 1000);
 
   const onChangeDateRange = (newRange) => {
-    refine({
-      min: newRange[0].getTime() / 1000,
-      max: newRange[1].getTime() / 1000,
-    });
+    if (newRange) {
+      refine({
+        min: newRange[0].getTime() / 1000,
+        max: newRange[1].getTime() / 1000,
+      });
+    } else {
+      // Reset to defaults when newRange is null
+      refine({
+        min,
+        max,
+      });
+    }
   };
 
   return (

--- a/src/components/instantsearch/dateRangeInput.js
+++ b/src/components/instantsearch/dateRangeInput.js
@@ -20,7 +20,7 @@ const StyledDateRangePicker = styled(DateRangePicker)`
     padding: 0 0.2rem;
   }
   .react-daterange-picker__inputGroup {
-    min-width: none;
+    min-width: auto;
   }
 `;
 

--- a/src/components/instantsearch/dateRangeInput.js
+++ b/src/components/instantsearch/dateRangeInput.js
@@ -4,11 +4,25 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { connectRange } from 'react-instantsearch-dom';
 import DateRangePicker from '@wojtekmaj/react-daterange-picker';
 
 import useDebounce from '../../hooks/useDebounce';
+
+const StyledDateRangePicker = styled(DateRangePicker)`
+  .react-daterange-picker__wrapper {
+    border: 0px;
+    justify-content: space-between;
+  }
+  .react-daterange-picker__range-divider {
+    padding: 0 0.2rem;
+  }
+  .react-daterange-picker__inputGroup {
+    min-width: none;
+  }
+`;
 
 /**
  * Min/max date range selector component.
@@ -34,9 +48,9 @@ const DateRangeInputCore = ({ currentRefinement, refine, min, max }) => {
   };
 
   return (
-    <DateRangePicker
+    <StyledDateRangePicker
       disableCalendar
-      rangeDivider=" to "
+      rangeDivider="to"
       onChange={onChangeDateRange}
       value={[
         new Date(debouncedCurrentRefinement.min * 1000),

--- a/src/components/instantsearch/dateRangeInput.js
+++ b/src/components/instantsearch/dateRangeInput.js
@@ -22,6 +22,12 @@ const StyledDateRangePicker = styled(DateRangePicker)`
   .react-daterange-picker__inputGroup {
     min-width: auto;
   }
+  .react-daterange-picker__inputGroup input {
+    color: var(--c-text);
+  }
+  .react-daterange-picker__clear-button {
+    color: var(--c-text);
+  }
 `;
 
 /**

--- a/src/components/instantsearch/dateRangeInput.js
+++ b/src/components/instantsearch/dateRangeInput.js
@@ -1,0 +1,34 @@
+/*
+ * Customized version of the RangeInput widget that allows a user to select
+ * a range of dates.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connectRange } from 'react-instantsearch-dom';
+
+/**
+ * Min/max date range selector component.
+ */
+const DateRangeInputCore = ({ currentRefinement, min, max, refine }) => {
+  console.log(currentRefinement);
+  console.log(min);
+  console.log(max);
+  console.log(refine);
+  return (
+    <div>
+      {currentRefinement.min} to {currentRefinement.max}
+    </div>
+  );
+};
+
+DateRangeInputCore.propTypes = {
+  currentRefinement: PropTypes.object.isRequired,
+  min: PropTypes.number.isRequired,
+  max: PropTypes.number.isRequired,
+  refine: PropTypes.func.isRequired,
+};
+
+const DateRangeInput = connectRange(DateRangeInputCore);
+
+export default DateRangeInput;

--- a/src/components/refinementOptIn.js
+++ b/src/components/refinementOptIn.js
@@ -1,0 +1,42 @@
+/*
+ * A component that allows a user to press a button to have a refinement
+ * appear. This allows us to only add constraining filters if a user wants
+ * to actual filter on that dimension (such as by date).
+ */
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import Button from './basics/buttons';
+
+const Wrapper = styled.div`
+  button {
+    margin-top: var(--space-xs);
+  }
+`;
+
+export default function RefinementOptIn({ children }) {
+  const [enableRefinement, setEnableRefinement] = useState(false);
+
+  if (enableRefinement) {
+    return (
+      <Wrapper>
+        {children}
+
+        <Button type="button" onClick={() => setEnableRefinement(false)}>
+          Clear filter
+        </Button>
+      </Wrapper>
+    );
+  }
+
+  return (
+    <Button type="button" onClick={() => setEnableRefinement(true)}>
+      + Add filter
+    </Button>
+  );
+}
+
+RefinementOptIn.propTypes = {
+  children: PropTypes.elementType.isRequired,
+};

--- a/src/icons/history.svg
+++ b/src/icons/history.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon-history"><path class="primary" d="M6.55 6.14l1.16 1.15A1 1 0 0 1 7 9H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1.7-.7l1.44 1.42A10 10 0 1 1 2 12a1 1 0 0 1 2 0 8 8 0 1 0 2.55-5.86z"/><path class="secondary" d="M15.7 14.3a1 1 0 0 1-1.4 1.4l-3-3a1 1 0 0 1-.3-.7V7a1 1 0 0 1 2 0v4.59l2.7 2.7z"/></svg>

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -25,6 +25,7 @@ import NonEmptyHits from '../components/instantsearch/nonEmptyHits';
 import DetailsToggleButton from '../components/detailsToggle';
 import SearchSettingsCluster from '../components/searchSettingsCluster';
 import DateRangeInput from '../components/instantsearch/dateRangeInput';
+import RefinementOptIn from '../components/refinementOptIn';
 
 const searchClient = algoliasearch(
   '0OJETYIVL5',
@@ -137,20 +138,24 @@ const AdvancedSearchPage = ({ location }) => {
 
             <SearchRefinementSection>
               <h2>Date updated</h2>
-              <DateRangeInput
-                attribute="sourceUpdateTimestamp"
-                min={startDate.getTime() / 1000}
-                max={tomorrow.getTime() / 1000}
-              />
+              <RefinementOptIn>
+                <DateRangeInput
+                  attribute="sourceUpdateTimestamp"
+                  min={startDate.getTime() / 1000}
+                  max={tomorrow.getTime() / 1000}
+                />
+              </RefinementOptIn>
             </SearchRefinementSection>
 
             <SearchRefinementSection>
               <h2>Date created</h2>
-              <DateRangeInput
-                attribute="sourceCreationTimestamp"
-                min={startDate.getTime() / 1000}
-                max={tomorrow.getTime() / 1000}
-              />
+              <RefinementOptIn>
+                <DateRangeInput
+                  attribute="sourceCreationTimestamp"
+                  min={startDate.getTime() / 1000}
+                  max={tomorrow.getTime() / 1000}
+                />
+              </RefinementOptIn>
             </SearchRefinementSection>
           </SearchRefinementsArea>
 

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -24,6 +24,7 @@ import CurrentRefinements from '../components/instantsearch/currentRefinements';
 import NonEmptyHits from '../components/instantsearch/nonEmptyHits';
 import DetailsToggleButton from '../components/detailsToggle';
 import SearchSettingsCluster from '../components/searchSettingsCluster';
+import DateRangeInput from '../components/instantsearch/dateRangeInput';
 
 const searchClient = algoliasearch(
   '0OJETYIVL5',
@@ -33,7 +34,7 @@ const searchClient = algoliasearch(
 /**
  * Create the URL parameters from the state.
  */
-const createUrlParams = state => `?${qs.stringify(state)}`;
+const createUrlParams = (state) => `?${qs.stringify(state)}`;
 
 /**
  * Create a full URL from the search state.
@@ -59,7 +60,7 @@ const AdvancedSearchPage = ({ location }) => {
   );
   const debouncedSearchState = useDebounce(searchState, DEBOUNCE_TIME);
 
-  const onSearchStateChange = updatedSearchState => {
+  const onSearchStateChange = (updatedSearchState) => {
     setSearchState(updatedSearchState);
   };
 
@@ -81,6 +82,12 @@ const AdvancedSearchPage = ({ location }) => {
     },
     [debouncedSearchState, location]
   );
+
+  const startDate = new Date(2015, 0, 1);
+  const today = new Date();
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(0, 0, 0, 0);
 
   return (
     <Layout>
@@ -126,6 +133,24 @@ const AdvancedSearchPage = ({ location }) => {
             <SearchRefinementSection>
               <h2>Contributors</h2>
               <RefinementList attribute="authorNames" />
+            </SearchRefinementSection>
+
+            <SearchRefinementSection>
+              <h2>Date updated</h2>
+              <DateRangeInput
+                attribute="sourceUpdateTimestamp"
+                min={startDate.getTime() / 1000}
+                max={tomorrow.getTime() / 1000}
+              />
+            </SearchRefinementSection>
+
+            <SearchRefinementSection>
+              <h2>Date created</h2>
+              <DateRangeInput
+                attribute="sourceCreationTimestamp"
+                min={startDate.getTime() / 1000}
+                max={tomorrow.getTime() / 1000}
+              />
             </SearchRefinementSection>
           </SearchRefinementsArea>
 

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -28,6 +28,7 @@ import DetailsToggleButton from '../components/detailsToggle';
 import SearchSettingsCluster from '../components/searchSettingsCluster';
 import AutoSortBy from '../components/instantsearch/autoSortBy';
 import DateRangeInput from '../components/instantsearch/dateRangeInput';
+import RefinementOptIn from '../components/refinementOptIn';
 
 const searchClient = algoliasearch(
   '0OJETYIVL5',
@@ -135,20 +136,24 @@ export default function DocSeriesTemplate({
 
             <SearchRefinementSection>
               <h2>Date updated</h2>
-              <DateRangeInput
-                attribute="sourceUpdateTimestamp"
-                min={startDate.getTime() / 1000}
-                max={tomorrow.getTime() / 1000}
-              />
+              <RefinementOptIn>
+                <DateRangeInput
+                  attribute="sourceUpdateTimestamp"
+                  min={startDate.getTime() / 1000}
+                  max={tomorrow.getTime() / 1000}
+                />
+              </RefinementOptIn>
             </SearchRefinementSection>
 
             <SearchRefinementSection>
               <h2>Date created</h2>
-              <DateRangeInput
-                attribute="sourceCreationTimestamp"
-                min={startDate.getTime() / 1000}
-                max={tomorrow.getTime() / 1000}
-              />
+              <RefinementOptIn>
+                <DateRangeInput
+                  attribute="sourceCreationTimestamp"
+                  min={startDate.getTime() / 1000}
+                  max={tomorrow.getTime() / 1000}
+                />
+              </RefinementOptIn>
             </SearchRefinementSection>
           </SearchRefinementsArea>
 

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -134,6 +134,15 @@ export default function DocSeriesTemplate({
             </SearchRefinementSection>
 
             <SearchRefinementSection>
+              <h2>Date updated</h2>
+              <DateRangeInput
+                attribute="sourceUpdateTimestamp"
+                min={startDate.getTime() / 1000}
+                max={tomorrow.getTime() / 1000}
+              />
+            </SearchRefinementSection>
+
+            <SearchRefinementSection>
               <h2>Date created</h2>
               <DateRangeInput
                 attribute="sourceCreationTimestamp"

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -27,6 +27,7 @@ import { StyledHits } from '../components/instantsearch/hits';
 import DetailsToggleButton from '../components/detailsToggle';
 import SearchSettingsCluster from '../components/searchSettingsCluster';
 import AutoSortBy from '../components/instantsearch/autoSortBy';
+import DateRangeInput from '../components/instantsearch/dateRangeInput';
 
 const searchClient = algoliasearch(
   '0OJETYIVL5',
@@ -36,7 +37,7 @@ const searchClient = algoliasearch(
 /**
  * Create the URL parameters from the state.
  */
-const createUrlParams = state => `?${qs.stringify(state)}`;
+const createUrlParams = (state) => `?${qs.stringify(state)}`;
 
 /**
  * Create a full URL from the search state.
@@ -65,7 +66,7 @@ export default function DocSeriesTemplate({
   );
   const debouncedSearchState = useDebounce(searchState, DEBOUNCE_TIME);
 
-  const onSearchStateChange = updatedSearchState => {
+  const onSearchStateChange = (updatedSearchState) => {
     setSearchState(updatedSearchState);
   };
 
@@ -124,6 +125,14 @@ export default function DocSeriesTemplate({
             <SearchRefinementSection>
               <h2>Contributors</h2>
               <RefinementList attribute="authorNames" />
+            </SearchRefinementSection>
+            <SearchRefinementSection>
+              <h2>Date created</h2>
+              <DateRangeInput
+                attribute="sourceCreationTimestamp"
+                min={1420088400}
+                max={1672549199}
+              />
             </SearchRefinementSection>
           </SearchRefinementsArea>
 

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -89,6 +89,9 @@ export default function DocSeriesTemplate({
     [debouncedSearchState, location]
   );
 
+  const startDate = new Date(2015, 0, 1);
+  const now = new Date();
+
   return (
     <Layout>
       <SEO title={docSeries.name} description={docSeries.description} />
@@ -126,12 +129,13 @@ export default function DocSeriesTemplate({
               <h2>Contributors</h2>
               <RefinementList attribute="authorNames" />
             </SearchRefinementSection>
+
             <SearchRefinementSection>
               <h2>Date created</h2>
               <DateRangeInput
                 attribute="sourceCreationTimestamp"
-                min={1420088400}
-                max={1672549199}
+                min={startDate.getTime() / 1000}
+                max={now.getTime() / 1000}
               />
             </SearchRefinementSection>
           </SearchRefinementsArea>

--- a/src/templates/docSeries.js
+++ b/src/templates/docSeries.js
@@ -90,7 +90,10 @@ export default function DocSeriesTemplate({
   );
 
   const startDate = new Date(2015, 0, 1);
-  const now = new Date();
+  const today = new Date();
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(0, 0, 0, 0);
 
   return (
     <Layout>
@@ -135,7 +138,7 @@ export default function DocSeriesTemplate({
               <DateRangeInput
                 attribute="sourceCreationTimestamp"
                 min={startDate.getTime() / 1000}
-                max={now.getTime() / 1000}
+                max={tomorrow.getTime() / 1000}
               />
             </SearchRefinementSection>
           </SearchRefinementsArea>


### PR DESCRIPTION
This PR enables a user filter by both update and creation timestamps that are now captured by ook since lsst-sqre/ook#56. These new refinements are based on the [react-datetime-picker](https://github.com/wojtekmaj/react-daterange-picker). The date-based filters are implemented with an opt-in button (through `RefinementOptIn`) because if the date attribute is not present in the record the resource would be immediately excluded from any result, even if the user didn't explicitly initiate a date-based filter. The `RefinementOptIn` component essentially mounts the refinement component in the virtual DOM only when the user selects it.