### PR TITLE
DM-40673: Configure the main branch to upload to www.lsst.io

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,3 +60,12 @@ jobs:
 
       - name: Build Gatsby site
         run: npm run build
+
+      - name: Upload
+        if: github.ref == 'refs/heads/main'
+        uses: lsst-sqre/ltd-upload@v1
+        with:
+          project: 'www'
+          dir: 'public'
+          username: ${{ secrets.LTD_USERNAME }}
+          password: ${{ secrets.LTD_PASSWORD }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,23 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Read .nvmrc
-        id: node_version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/checkout@v4
 
       - name: Set up node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version-file: .nvmrc
+          cache: 'npm'
 
       - name: Install npm packages
         run: npm install .
@@ -37,23 +27,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Read .nvmrc
-        id: node_version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/checkout@v4
 
       - name: Set up node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version-file: .nvmrc
+          cache: 'npm'
 
       - name: Install npm packages
         run: npm install .


### PR DESCRIPTION
Since Gatsby Cloud is being discontinued, and its replacement Netlify can't deploy to www. without controlling the apex DNS as well, we'll go back to using LSST the Docs to host the documentation portal.