### PR TITLE
DM-49054: Add CTN document series page

### DIFF
--- a/src/data/docSeries.yaml
+++ b/src/data/docSeries.yaml
@@ -3,6 +3,9 @@
 # Each item is transformed into a category search page for that document
 # series in gatsby-node.js
 
+- key: CTN
+  name: Camera Technotes
+
 - key: DMTN
   name: Data Management Technotes
 


### PR DESCRIPTION
Add the /ctn page for the new Camera technical notes series.