### PR TITLE
Add plausible.io website analytics for lsst.io

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -69,6 +69,13 @@ function SEO({ description, lang, meta, title }) {
           content: metaDescription,
         },
       ].concat(meta)}
+      script={[
+        {
+          defer: true,
+          'data-domain': 'lsst.io',
+          src: 'https://plausible.io/js/script.file-downloads.hash.outbound-links.js',
+        },
+      ]}
     />
   );
 }


### PR DESCRIPTION
This shares the same tracking domain between www.lsst.io and the individual documentation projects to see how search is being used.