### PR TITLE
DM-55493: Add the SOTN series and correct the Felis guide entry

### DIFF
--- a/src/data/docSeries.yaml
+++ b/src/data/docSeries.yaml
@@ -54,6 +54,9 @@
 - key: SITCOMTN
   name: Systems Integration, Testing, and Commissioning Technotes
 
+- key: SOTN
+  name: Summit Operations Technical Notes
+
 - key: SQR
   name: SQuaRE Technotes
 

--- a/src/data/guides.yaml
+++ b/src/data/guides.yaml
@@ -81,12 +81,12 @@
 
 - slug: felis
   title: Felis
-  github: lsst-dm/felis
+  github: lsst/felis
   tags:
     - org/dm
     - system/pipelines
   description: >
-    Felis is a way of describing database catalogs, scientific and otherwise, in a language and DBMS agnostic way. It’s built on concepts from JSON-LD/RDF and CSVW, but intended to provide a comprehensive way to describe tabular data, using annotations on tables, columns, and schemas, to document scientifically useful metadata as well as implementation-specific metadata for database management systems, file formats, and application data models.
+    Felis is a way of describing astronomical database catalogs in a language and DBMS agnostic format. It provides a comprehensive way to describe tabular data, using annotations on tables, columns, and schemas, to document scientifically useful metadata as well as implementation-specific metadata for database management systems, file formats, and application data models.
 
 
 - slug: firefly


### PR DESCRIPTION
## Summary

Two independent data-file corrections to the site's series and guide indexes.

### Add the SOTN document series (`src/data/docSeries.yaml`)

- Adds `SOTN` (Summit Operations Technical Notes). The series has eight published documents on lsst.io but no presence on www.lsst.io — it was missing from the homepage "browse by series" grid and had no browse-and-search page.
- Series are fully data-driven from that one YAML file, so the single entry automatically yields the homepage NavGrid card, the `/sotn/` route (via `gatsby-node.js` + `src/templates/docSeries.js`), the SEO description, and a sitemap entry. No other file needs to change.
- No `notice:` field: that's reserved for the DocuShare-era series (DMTR, LDM, LPM, LSE) and doesn't apply to an lsst.io technote series.

### Correct the Felis guide entry (`src/data/guides.yaml`)

Requested by the Felis maintainers, for `/pipelines-guides/`:

- The GitHub repository moved from `lsst-dm/felis` to `lsst/felis`.
- The description was inaccurate and outdated (it described the format as built on JSON-LD/RDF and CSVW concepts). Replaced with updated text supplied by the maintainers.

## Known limitation (not fixed here)

Ook has currently indexed only **SOTN-008** into the Algolia index, even though SOTN-001–008 are all live on lsst.io. Querying the index the page uses (`document_dev_handle_desc`) with the template's filter `series:SOTN` returns `nbHits: 1`.

So `/sotn/` renders correctly but will list a single document until Ook ingests SOTN-001–007. That's an `lsst-sqre/ook` concern, out of scope for this repo, but worth tracking.

## Validation steps

- Load `/` and confirm the Documents section's series grid shows a **SOTN** card in alphabetical position, between SITCOMTN and SQR; click through to `/sotn/`.
- Load `/sotn/` and confirm the heading reads "Summit Operations Technical Notes", there is no notice paragraph, and the search results list SOTN-008. (A single result is the expected outcome today — see the limitation above.)
- Load `/pipelines-guides/` and confirm the Felis card shows the new description and that its GitHub link resolves to `https://github.com/lsst/felis`.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55493