### PR TITLE
DM-55493: Fix the Netlify build by keeping sharp on prebuilt binaries

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,27 @@
+# Netlify build configuration.
+#
+# The build settings here (command, publish) mirror what was previously
+# configured only through the Netlify UI, so that they are visible and
+# reviewable in the repo.
+
+[build]
+  command = "npm run build"
+  publish = "public"
+
+[build.environment]
+  # Netlify's build image ships a global libvips. Without this, sharp finds it
+  # and compiles from source instead of downloading its prebuilt binary. That
+  # compile runs through the node-gyp bundled with npm 6, whose vendored gyp
+  # opens files with mode 'rU' -- removed in Python 3.11, and the build image now
+  # ships Python 3.14. Ignoring the global libvips restores the prebuilt path.
+  #
+  # This bites the sharp inside the Essential Gatsby plugin, which Netlify
+  # auto-installs for Gatsby <= 5.11 and which we cannot uninstall from the UI.
+  SHARP_IGNORE_GLOBAL_LIBVIPS = "1"
+
+  # Overrides .nvmrc for Netlify's Linux builder only. The Essential Gatsby
+  # plugin declares engines >= 14.17.0, so 14.15.0 trips an unsupported-engine
+  # warning. .nvmrc stays at 14.15.0 because Node 14 has no macOS arm64 build,
+  # so developers on Apple Silicon cannot install a newer 14.x without
+  # compiling it from source.
+  NODE_VERSION = "14.21.3"


### PR DESCRIPTION
## Summary

- Netlify deploys currently fail before the site build even starts. Their build image now ships a global libvips and Python 3.14. The Essential Gatsby plugin — which Netlify auto-installs for Gatsby <= 5.11, and which cannot be uninstalled from the UI — depends on sharp 0.32.6. sharp finds the global libvips and compiles from source instead of downloading its prebuilt binary. That compile runs through the node-gyp bundled with npm 6, whose vendored gyp opens files with mode `rU`, removed in Python 3.11. Dependency installation dies there.
- Adds `netlify.toml` setting `SHARP_IGNORE_GLOBAL_LIBVIPS`, so sharp fetches its N-API prebuilt binary and skips node-gyp (and therefore Python) entirely. Both required prebuilt binaries are published for linux-x64, for the plugin's sharp 0.32.6 and this site's own sharp 0.29.1.
- Also pins the builder to the last Node 14 release, satisfying the plugin's `engines` requirement of `>= 14.17.0`, and moves the build command and publish directory out of the Netlify UI into the repo so they are visible and reviewable. `.nvmrc` deliberately stays at 14.15.0: Node 14 has no macOS arm64 build, so bumping it would break local development on Apple Silicon.

This is a deliberately minimal fix to unblock deploys. It does not upgrade Gatsby or Node, since this site is slated to be replaced by the Gatsby site in the `lsst-sqre/squareone` monorepo.

## Validation steps

- Confirm the Netlify deploy preview for this PR builds successfully, where builds on `main` currently fail.
- In the deploy preview build log, confirm sharp downloads a prebuilt binary rather than logging `Building from source via node-gyp`.
- Load the deploy preview and confirm the site renders, including images (which are what sharp processes) and the Algolia-backed search.

Note: `npm run format:check` already fails on `main` for nine unrelated, unformatted `.js` files. That is pre-existing and untouched here.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55493