### PR TITLE
DM-55688: Move dependabot to monthly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,20 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: "monthly"
+      time: "03:00"
+      timezone: "America/New_York"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: "monthly"
+      time: "03:00"
+      timezone: "America/New_York"
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Move both `dependabot.yml` update entries (github-actions, npm) to a monthly schedule (03:00 America/New_York), replacing the previous weekly cadence.
- Add a wildcard `groups:` entry for each ecosystem so updates land as a single grouped PR per month instead of individual PRs.

## Jira
DM-55688

## Test plan
- [x] `grep -nE "interval: ['\"]?(weekly|daily)" .github/dependabot.yml` prints nothing
- [x] `grep -c "interval: "` equals `grep -c "monthly"` (2 == 2)
- [x] every `updates:` entry has a `groups:` key
- [x] `github-actions` entry present; no Dockerfile or pnpm-lock.yaml at repo root beyond existing `npm` entry (package-lock.json present, npm entry already existed)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` exits 0
- [x] confirmed Dependabot security alerts + automated fixes already enabled on the repo (no settings change needed)